### PR TITLE
Makefile: split build and run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 *.out
 
 /_output
-/openstack-test
+/openstack-tests

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,13 @@ test: test-tools
 # and also hooked into {update,verify}-generated for broader integration.
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
 
-openstack-test:
-	go build -o openstack-test ./cmd/openshift-tests
-	./openstack-test run --run '\[Feature:openstack\]' openshift/conformance
+openstack-tests: test/extended/openstack/*
+	go build -o $@ ./cmd/openshift-tests
+
+run: openstack-tests
+	./$< run --run '\[Feature:openstack\]' openshift/conformance
+.PHONY: run
+
+# For backwards compatibility
+openstack-test: run
 .PHONY: openstack-test

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 This repository contains tests specific to OpenShift on OpenStack.
 
+The tests sit in [`test/extended/openstack`][2]
+
 Run the tests by:
 1. `export OS_CLOUD=<OS_CLOUD>`
 1. `export KUBECONFIG=<kubeconfig>`
-1. `make openstack-test`
+1. `make run`
 
 The machinery is ported from [openshift/origin][1].
 
-[1]: https:github.com/openshift/origin
+[1]: https://github.com/openshift/origin
+[2]: test/extended/openstack


### PR DESCRIPTION
With this patch, the Makefile targets for building and running the tests
are now separate. A conditional is also set on the build target to only
rebuild in case of changes to the OpenStack tests.

Also with this patch, the compiled binary is now called
`openstack-tests` instead of `openstack-test`, as [recommended][1].

The legacy `openstack-test` target is added for backwards compatibility.

[1]: https://github.com/openshift/release/pull/22556#discussion_r735627024