### PR TITLE
[Fix]Put in order the obtained IP lists

### DIFF
--- a/test/extended/openstack/servers.go
+++ b/test/extended/openstack/servers.go
@@ -109,7 +109,7 @@ var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", 
 				instance, err := servers.Get(computeClient, machine.Get("metadata.annotations.openstack-resourceId").String()).Extract()
 				o.Expect(err).NotTo(o.HaveOccurred(), "Error gathering Openstack info for machine %v", machine.Get("metadata.name"))
 				g.By(fmt.Sprintf("Compare addresses with openstack interfaces for machine %q", instance.Name))
-				o.Expect(parseInstanceAddresses(instance.Addresses)).To(o.Equal(getAddressesFromMachine(machine)), "Addresses not matching for instance %q", instance.Name)
+				o.Expect(parseInstanceAddresses(instance.Addresses)).To(o.ConsistOf(getAddressesFromMachine(machine)), "Addresses not matching for instance %q", instance.Name)
 			}
 		})
 


### PR DESCRIPTION
On D/S CI, it is observed that the IP comparison is failing due to a
wrong order in the obtained lists:

Addresses not matching for instance "ostest-mdbrl-worker-0-d9p6c"
Expected
    <[]string | len:2, cap:2>: ["172.17.5.233", "10.196.3.227"]
to equal
    <[]string | len:2, cap:4>: ["10.196.3.227", "172.17.5.233"]

This fix is changing the check from Equal to ConsistOf so the order
is not considered.