### PR TITLE
do not look for ServiceAccount token secrets

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -986,24 +986,18 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 			}
 			return false, fmt.Errorf("Failed to get service account %q: %v", name, err)
 		}
-		secretNames := []string{}
-		var hasDockercfg, hasToken bool
-		for _, s := range sc.Secrets {
-			if strings.Contains(s.Name, "-token-") {
-				hasToken = true
-			}
-			secretNames = append(secretNames, s.Name)
-		}
+		var secretNames []string
+		var hasDockerCfg bool
 		for _, s := range sc.ImagePullSecrets {
 			if strings.Contains(s.Name, "-dockercfg-") {
-				hasDockercfg = true
+				hasDockerCfg = true
 			}
 			secretNames = append(secretNames, s.Name)
 		}
-		if hasDockercfg && hasToken {
+		if hasDockerCfg {
 			return true, nil
 		}
-		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg/token ...", name, strings.Join(secretNames, ","))
+		e2e.Logf("Waiting for service account %q secrets (%s) to include dockercfg ...", name, strings.Join(secretNames, ","))
 		return false, nil
 	}
 	return wait.Poll(100*time.Millisecond, 3*time.Minute, waitFn)


### PR DESCRIPTION
token secrets go away in kube 1.24
