### PR TITLE
Disable invariance checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ openstack-tests: test/extended/openstack/*
 	go build -o $@ ./cmd/openshift-tests
 
 run: openstack-tests
-	./$< run --run '\[Feature:openstack\]' openshift/conformance
+	./$< run openshift/openstack
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,3 @@ openstack-tests: test/extended/openstack/*
 run: openstack-tests
 	./$< run --run '\[Feature:openstack\]' openshift/conformance
 .PHONY: run
-
-# For backwards compatibility
-openstack-test: run
-.PHONY: openstack-test

--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -75,6 +75,22 @@ func (s testSuites) TestSuites() []*ginkgo.TestSuite {
 var staticSuites = testSuites{
 	{
 		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/openstack",
+			Description: templates.LongDesc(`
+		Tests that verify OpenStack-specific invariants.
+		`),
+			Matches: func(name string) bool {
+				if isDisabled(name) {
+					return false
+				}
+				return strings.Contains(name, "[Suite:openshift/openstack")
+			},
+			Parallelism: 30,
+		},
+		PreSuite: suiteWithProviderPreSuite,
+	},
+	{
+		TestSuite: ginkgo.TestSuite{
 			Name: "openshift/conformance",
 			Description: templates.LongDesc(`
 		Tests that ensure an OpenShift cluster and components are working properly.

--- a/test/extended/openstack/kuryr.go
+++ b/test/extended/openstack/kuryr.go
@@ -15,7 +15,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack][Kuryr] Kuryr", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack][Kuryr] Kuryr", func() {
 	var networkClient *gophercloud.ServiceClient
 	var dc dynamic.Interface
 	var clientSet *kubernetes.Clientset

--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -21,7 +21,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var computeClient *gophercloud.ServiceClient

--- a/test/extended/openstack/servers.go
+++ b/test/extended/openstack/servers.go
@@ -34,7 +34,7 @@ const (
 	machineSetOwningLabel = "machine.openshift.io/cluster-api-machineset"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var dc dynamic.Interface

--- a/test/extended/openstack/volumes.go
+++ b/test/extended/openstack/volumes.go
@@ -24,7 +24,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var dc dynamic.Interface

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -713,21 +713,21 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client kubectl wait should ignore not found error with --for=delete": "should ignore not found error with --for=delete [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "should follow PVC specs during resizing for prometheus [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "should follow PVC specs during resizing for prometheus [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack][Kuryr] Kuryr should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace": "should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack][Kuryr] Kuryr should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace": "should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 


### PR DESCRIPTION
Do no execute invariant verification while running platform-specific
tests.

This change is expected to reduce noise, while invariant tests are run
alongside the main openshift/conformance run.