### PR TITLE
Remove obsolete Feature:openstack label

### DIFF
--- a/test/extended/openstack/kuryr.go
+++ b/test/extended/openstack/kuryr.go
@@ -13,7 +13,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack][Kuryr] Kuryr", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Kuryr] Kuryr", func() {
 	var clientSet *kubernetes.Clientset
 
 	g.BeforeEach(func() {

--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -21,7 +21,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var computeClient *gophercloud.ServiceClient

--- a/test/extended/openstack/servers.go
+++ b/test/extended/openstack/servers.go
@@ -34,7 +34,7 @@ const (
 	machineSetOwningLabel = "machine.openshift.io/cluster-api-machineset"
 )
 
-var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var dc dynamic.Interface

--- a/test/extended/openstack/volumes.go
+++ b/test/extended/openstack/volumes.go
@@ -24,7 +24,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var dc dynamic.Interface

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -713,21 +713,21 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-cli] Kubectl client kubectl wait should ignore not found error with --for=delete": "should ignore not found error with --for=delete [Disabled:Broken] [Suite:k8s]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "should follow PVC specs during resizing for prometheus [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "should follow PVC specs during resizing for prometheus [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Suite:openshift/openstack][Feature:openstack][Kuryr] Kuryr should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace": "should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack][Kuryr] Kuryr should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace": "should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 


### PR DESCRIPTION
We now track openshift/openstack tests with
`[Suite:openshift/openstack]`.

/hold until https://github.com/openshift/release/pull/29854 is merged