### PR TITLE
Create suite openshift/openstack

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -40,6 +40,22 @@ func (s testSuites) TestSuites() []*ginkgo.TestSuite {
 var staticSuites = testSuites{
 	{
 		TestSuite: ginkgo.TestSuite{
+			Name: "openshift/openstack",
+			Description: templates.LongDesc(`
+		Tests that verify OpenStack-specific invariants.
+		`),
+			Matches: func(name string) bool {
+				if isDisabled(name) {
+					return false
+				}
+				return strings.Contains(name, "[Suite:openshift/openstack")
+			},
+			Parallelism: 30,
+		},
+		PreSuite: suiteWithProviderPreSuite,
+	},
+	{
+		TestSuite: ginkgo.TestSuite{
 			Name: "openshift/conformance",
 			Description: templates.LongDesc(`
 		Tests that ensure an OpenShift cluster and components are working properly.

--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -21,7 +21,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var computeClient *gophercloud.ServiceClient

--- a/test/extended/openstack/servers.go
+++ b/test/extended/openstack/servers.go
@@ -34,7 +34,7 @@ const (
 	machineSetOwningLabel = "machine.openshift.io/cluster-api-machineset"
 )
 
-var _ = g.Describe("[sig-installer][Feature:openstack] The OpenStack platform", func() {
+var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack platform", func() {
 	defer g.GinkgoRecover()
 
 	var dc dynamic.Interface

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2,7 +2,6 @@ package generated
 
 import (
 	"fmt"
-
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/types"
 )
@@ -1650,16 +1649,17 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-installer][Feature:baremetal] Baremetal platform should have baremetalhost resources": "have baremetalhost resources [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Control plane nodes in a server group": "creates Control plane nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes in a server group": "creates Worker nodes in a server group [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity [Suite:openshift/conformance/parallel]",
 
-	"[Top Level] [sig-installer][Feature:openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should follow machineset specs": "should follow machineset specs [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "should include the addresses on the machine specs [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 


### PR DESCRIPTION
Disable invariance checks by running OpenStack tests in their own new suite `openshift/openstack`.

Label all openstack tests with `[Suite:openstack]`.

This is a backport of:
* bdc3567bcd225c45916a24736fb976feaa4389b6 (https://github.com/openshift/openstack-test/pull/33)
* 61409a88ec92dddabb836be062cbd2ed77a248ab (https://github.com/openshift/openstack-test/pull/35)

/hold until https://github.com/openshift/release/pull/29854 is merged