### PR TITLE
Add udp-lb testcase for ovn provider

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -737,6 +737,8 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should create an UDP Amphora LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift": "should create an UDP Amphora LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift": "should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-instrumentation] Events API should ensure that an event can be fetched, patched, deleted, and listed [Conformance]": "should ensure that an event can be fetched, patched, deleted, and listed [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",


### PR DESCRIPTION
Covers partially the epic https://issues.redhat.com/browse/OSASINFRA-2753

This test creates an UDP lb when OVN provider is configured on the cluster and checks the created Openstack resources. It also sends 100 requests to the LoadBalancer Service and analyze the pods' responses so that the e2e functionality is verified.

This test will be skipped for Kuryr NetworkType and if cloudProviderConfig is configuring a different lb-provider than OVN.