### PR TITLE
Add udp shared lb testcases

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -739,6 +739,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift": "should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should re-use an existing UDP Amphora LoadBalancer when new svc is created on Openshift with the proper annotation": "should re-use an existing UDP Amphora LoadBalancer when new svc is created on Openshift with the proper annotation [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should re-use an existing UDP OVN LoadBalancer when new svc is created on Openshift with the proper annotation": "should re-use an existing UDP OVN LoadBalancer when new svc is created on Openshift with the proper annotation [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-instrumentation] Events API should delete a collection of events [Conformance]": "should delete a collection of events [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",
 
 	"[Top Level] [sig-instrumentation] Events API should ensure that an event can be fetched, patched, deleted, and listed [Conformance]": "should ensure that an event can be fetched, patched, deleted, and listed [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]",


### PR DESCRIPTION
Covers partially the epic https://issues.redhat.com/browse/OSASINFRA-2753

This test creates an UDP lb svc and created a second one re-using the same openstack loadbalancer. It checks that the openstack loadbalancer is configured appropiatedly and the e2e connectivity works.

This test will be skipped for Kuryr NetworkType and if max-shared-lb has a value lower than 2.