### PR TITLE
Add monitors+etp:local testcases

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -735,6 +735,10 @@ var annotations = map[string]string{
 
 	"[Top Level] [sig-installer][Suite:openshift/openstack][Kuryr] Kuryr should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace": "should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace [Suite:openshift/conformance/parallel]",
 
+	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should apply lb-method on UDP Amphora LoadBalancer when an UDP svc with monitors and ETP:Local is created on Openshift": "should apply lb-method on UDP Amphora LoadBalancer when an UDP svc with monitors and ETP:Local is created on Openshift [Suite:openshift/conformance/parallel]",
+
+	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should apply lb-method on UDP OVN LoadBalancer when an UDP svc with monitors and ETP:Local is created on Openshift": "should apply lb-method on UDP OVN LoadBalancer when an UDP svc with monitors and ETP:Local is created on Openshift [Suite:openshift/conformance/parallel]",
+
 	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should create an UDP Amphora LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift": "should create an UDP Amphora LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift [Suite:openshift/conformance/parallel]",
 
 	"[Top Level] [sig-installer][Suite:openshift/openstack][lb] The Openstack platform should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift": "should create an UDP OVN LoadBalancer when an UDP svc with type:LoadBalancer is created on Openshift [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Covers partially the epic https://issues.redhat.com/browse/OSASINFRA-2753

Two tests, one for amphora and another for ovn provider.

They create an UDP lb svc enabling openstack monitors and configuring ETP:Local and then checking that the existing lbMethod is successfully applied.

These test will be skipped for Kuryr NetworkType.