### PR TITLE
Fix comparison of machine addresses with openstack instance addresses

### DIFF
--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -27,7 +27,14 @@ verify_generated() {
 	declare new='test/extended/util/annotate/generated/zz_generated.annotations.go'
 	cp "$new" "$old"
 	go generate ./test/extended
-	diff "$old" "$new"
+	if ! diff "$old" "$new"; then
+            echo 'Generated files are out of date'
+            echo 'Run "make update"'
+            rm $old
+            return 1
+        fi
+        rm $old
+        return 0
 }
 
 declare run=0 failed=0 junit_testcases=''

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -755,7 +755,7 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should follow machineset specs": "",
 
-	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should include the addresses on the machine specs": "",
+	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on instance creation should report all openstack instance addresses on the corresponding Machine object": "",
 
 	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "",
 


### PR DESCRIPTION
Firstly this test was broken because skipUnlessMachineAPIOperator is broken and was executing against a UPI cluster. We address this by only fetching OpenStack instances for machines which exist. If no machines exist (because it's UPI) the test trivially succeeds.

Secondly we improve the error reporting. We update the gomega matchers to operate on the actual data. This means that if they don't match the non-matching data will be included in the error message.