### PR TITLE
OCPBUGS-7310: Do not consider deleted instance as error

### DIFF
--- a/test/extended/openstack/servers.go
+++ b/test/extended/openstack/servers.go
@@ -123,10 +123,10 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 
 				g.By(fmt.Sprintf("Gather Openstack attributes for machine %q", machineName))
 				instance, err := servers.Get(computeClient, machine.Get("metadata.annotations.openstack-resourceId").String()).Extract()
-				o.Expect(err).NotTo(o.HaveOccurred(), "Error gathering Openstack info for machine %v", machineName)
 
 				var gerr gophercloud.ErrDefault404
 				if !errors.As(err, &gerr) {
+					o.Expect(err).NotTo(o.HaveOccurred(), "Error gathering Openstack info for machine %v", machineName)
 					instanceAddresses, err := parseInstanceAddresses(instance.Addresses)
 					o.Expect(err).NotTo(o.HaveOccurred(), "Error parsing addresses for instance %q", instance.Name)
 					openstackIPs[machineName] = instanceAddresses


### PR DESCRIPTION
The `OpenStack platform on instance creation should report all openstack instance addresses on the corresponding Machine object` test list all machines in the openshift cluster then fetches information from OpenStack for each one of them. Because the test doesn't run in isolation, it's affected by other tests that run at the same time and it makes it flaky.

We had a check that looked for errors getting info for a machine that did not take into account deleted machines. Move this check at the right place.