### PR TITLE
Use context

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -40,7 +40,10 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 	var cloudNetworkClientset cloudnetwork.Interface
 	oc := exutil.NewCLI("openstack")
 
+	var ctx context.Context
+
 	g.BeforeEach(func() {
+		ctx = context.Background()
 
 		g.By("Loading the kubernetes clientset")
 		clientSet, err = e2e.LoadClientset()
@@ -50,18 +53,18 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating an openstack network client")
 
 		// TODO revert once https://issues.redhat.com/browse/OSASINFRA-3079 is resolved
-		proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
+		proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if proxy.Status.HTTPProxy != "" {
 			e2eskipper.Skipf("Test not applicable for proxy setup")
 		}
 
-		infrastructure, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		infrastructure, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		infraID = infrastructure.Status.InfrastructureName
 
 		g.By("Getting the worker node list")
-		workerNodeList, err = clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		workerNodeList, err = clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 			LabelSelector: "node-role.kubernetes.io/worker",
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -70,7 +73,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 	g.It("attached to a floating IP should be kept after EgressIP node failover with OVN-Kubernetes NetworkType", func() {
 
 		g.By("Getting the network type")
-		networkType, err := getNetworkType(oc)
+		networkType, err := getNetworkType(ctx, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if networkType != NetworkTypeOVNKubernetes {
 			e2eskipper.Skipf("Test not applicable for '%s' NetworkType (only valid for '%s')", networkType, NetworkTypeOVNKubernetes)
@@ -149,7 +152,7 @@ spec:
 		g.By("Waiting until CloudPrivateIPConfig is created and assigned to the primary worker node")
 		cloudNetworkClientset, err = cloudnetwork.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
-		waitOk, err := waitCloudPrivateIPConfigAssignedNode(cloudNetworkClientset, egressIPAddrStr, primaryWorker.Name)
+		waitOk, err := waitCloudPrivateIPConfigAssignedNode(ctx, cloudNetworkClientset, egressIPAddrStr, primaryWorker.Name)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(waitOk).To(o.BeTrue(), "Not found the expected assigned node '%s' in '%s' CloudPrivateIPConfig", primaryWorker.Name, egressIPAddrStr)
 		e2e.Logf("Found the expected assigned node '%s' in '%s' CloudPrivateIPConfig", primaryWorker.Name, egressIPAddrStr)
@@ -161,7 +164,7 @@ spec:
 
 		// Check the assigned node in CloudPrivateIPConfig is kept with the primary EgressIP worker node
 		g.By("Checking the CloudPrivateIPConfig object and the assigned node after adding a second EgressIP assignable node")
-		cpicAssignedNode, err := getCpipAssignedNode(cloudNetworkClientset, egressIPAddrStr)
+		cpicAssignedNode, err := getCpipAssignedNode(ctx, cloudNetworkClientset, egressIPAddrStr)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Could not find the assigned node in '%s' CloudPrivateIPConfig", egressIPAddrStr)
 		e2e.Logf("'%s' CloudPrivateIPConfig assigned node ('%s') is kept after adding a second assignable node", egressIPAddrStr, cpicAssignedNode)
 		o.Expect(cpicAssignedNode).To(o.Equal(primaryWorker.Name), "'%s' egressIP has been deassigned to the '%s' node", egressIPAddrStr, primaryWorker.Name)
@@ -195,7 +198,7 @@ spec:
 		e2e.RemoveLabelOffNode(clientSet, primaryWorker.Name, egressAssignableLabelKey)
 
 		g.By("Waiting until CloudPrivateIPConfig is updated with the secondary worker as assigned node")
-		waitOk, err = waitCloudPrivateIPConfigAssignedNode(cloudNetworkClientset, egressIPAddrStr, secondaryWorker.Name)
+		waitOk, err = waitCloudPrivateIPConfigAssignedNode(ctx, cloudNetworkClientset, egressIPAddrStr, secondaryWorker.Name)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(waitOk).To(o.BeTrue(), "Not found the expected assigned node '%s' in '%s' CloudPrivateIPConfig", secondaryWorker.Name, egressIPAddrStr)
 		e2e.Logf("Found the expected assigned node '%s' in '%s' CloudPrivateIPConfig", secondaryWorker.Name, egressIPAddrStr)
@@ -374,8 +377,8 @@ func incIP(ip net.IP) net.IP {
 }
 
 // getCpipAssignedNode returns the assigned node from a given CloudPrivateIPConfig
-func getCpipAssignedNode(cloudNetClientset cloudnetwork.Interface, egressIPAddr string) (string, error) {
-	privIPconfig, err := cloudNetClientset.CloudV1().CloudPrivateIPConfigs().Get(context.Background(), egressIPAddr, metav1.GetOptions{})
+func getCpipAssignedNode(ctx context.Context, cloudNetClientset cloudnetwork.Interface, egressIPAddr string) (string, error) {
+	privIPconfig, err := cloudNetClientset.CloudV1().CloudPrivateIPConfigs().Get(ctx, egressIPAddr, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -401,9 +404,9 @@ func getPortsByIP(client *gophercloud.ServiceClient, ipAddr string, networkID st
 }
 
 // Active Wait for CloudPrivateIPConfig resource in OCP to be assigned to the expected node
-func waitCloudPrivateIPConfigAssignedNode(cloudNetClientset cloudnetwork.Interface, egressIP string, node string) (bool, error) {
+func waitCloudPrivateIPConfigAssignedNode(ctx context.Context, cloudNetClientset cloudnetwork.Interface, egressIP string, node string) (bool, error) {
 	o.Eventually(func() bool {
-		privIPconfig, err := cloudNetClientset.CloudV1().CloudPrivateIPConfigs().Get(context.Background(), egressIP, metav1.GetOptions{})
+		privIPconfig, err := cloudNetClientset.CloudV1().CloudPrivateIPConfigs().Get(ctx, egressIP, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				e2e.Logf("'%s' CloudPrivateIPConfig not found", egressIP)

--- a/test/extended/openstack/kuryr.go
+++ b/test/extended/openstack/kuryr.go
@@ -16,7 +16,11 @@ import (
 var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Kuryr] Kuryr", func() {
 	var clientSet *kubernetes.Clientset
 
+	var ctx context.Context
+
 	g.BeforeEach(func() {
+		ctx = context.Background()
+
 		g.By("preparing openshift dynamic client")
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -25,7 +29,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Kuryr] Kuryr", fu
 
 		c, err := configv1client.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		network, err := c.ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
+		network, err := c.ConfigV1().Networks().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		if network.Status.NetworkType != "Kuryr" {
@@ -36,21 +40,21 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][Kuryr] Kuryr", fu
 	g.It("should create a subnet for a namespace only when a pod without hostNetwork is created in the namespace", func() {
 		g.By("Creating a Namespace and pods")
 		{
-			ns := CreateNamespace(clientSet, "kuryr-hostnetwork", true)
-			defer DeleteNamespace(clientSet, ns)
+			ns := CreateNamespace(ctx, clientSet, "kuryr-hostnetwork", true)
+			defer DeleteNamespace(ctx, clientSet, ns)
 			g.By("Creating a Pod with hostNetwork=true")
 			command := []string{"/bin/sleep", "120"}
-			_, err := CreatePod(clientSet, ns.Name, "kuryr-hostnetwork", true, command)
+			_, err := CreatePod(ctx, clientSet, ns.Name, "kuryr-hostnetwork", true, command)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			subnetID, err := GetSubnetIDfromKuryrNetwork(clientSet, ns.Name)
+			subnetID, err := GetSubnetIDfromKuryrNetwork(ctx, clientSet, ns.Name)
 			if !apierrors.IsNotFound(err) {
 				e2e.Failf("Error has occured %v", err)
 			}
 			o.Expect(subnetID).To(o.BeEmpty(), "A subnet should not be created when a pod with Hostnetwork is created")
 			g.By("Creating a Pod with hostNetwork=false")
-			_, err = CreatePod(clientSet, ns.Name, "kuryr-nohostnetwork", false, command)
+			_, err = CreatePod(ctx, clientSet, ns.Name, "kuryr-nohostnetwork", false, command)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			subnetID, err = GetSubnetIDfromKuryrNetwork(clientSet, ns.Name)
+			subnetID, err = GetSubnetIDfromKuryrNetwork(ctx, clientSet, ns.Name)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(subnetID).ToNot(o.BeEmpty(), "A subnet should be created when a non host network pod is created")
 		}

--- a/test/extended/openstack/machinesets.go
+++ b/test/extended/openstack/machinesets.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -34,6 +35,11 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 	var dc dynamic.Interface
 	var clientSet *kubernetes.Clientset
 
+	var ctx context.Context
+	g.BeforeEach(func() {
+		ctx = context.Background()
+	})
+
 	g.Context("after deletion of a machineset", func() {
 		g.BeforeEach(func() {
 			g.By("preparing openshift dynamic client")
@@ -48,7 +54,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 		g.It("should not have leftovers ports", func() {
 			// Check the scenario at https://bugzilla.redhat.com/show_bug.cgi?id=2073398
 
-			skipUnlessMachineAPIOperator(dc, clientSet.CoreV1().Namespaces())
+			skipUnlessMachineAPIOperator(ctx, dc, clientSet.CoreV1().Namespaces())
 			g.By("Fetching worker machineSets")
 			var networkClient *gophercloud.ServiceClient
 			var rawBytes []byte
@@ -57,7 +63,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 
 			networkClient, err := client(serviceNetwork)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error creating an openstack network client")
-			machineSets, err := listWorkerMachineSets(dc)
+			machineSets, err := listWorkerMachineSets(ctx, dc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error getting the workers machinesets")
 
 			if len(machineSets) == 0 {
@@ -94,13 +100,13 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create a Machineset")
 			defer DeleteMachinesetsDefer(rclient, ms)
 
-			err = GetMachinesetRetry(rclient, ms, true)
+			err = GetMachinesetRetry(ctx, rclient, ms, true)
 
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get the new Machineset")
 
 			g.By("Deleting the new machineset")
 			framework.DeleteMachineSets(rclient, ms)
-			err = GetMachinesetRetry(rclient, ms, false)
+			err = GetMachinesetRetry(ctx, rclient, ms, false)
 			o.Expect(errors.IsNotFound(err)).To(o.BeTrue(), "Machineset %v was not deleted", ms.Name)
 
 			var config machinev1alpha1.OpenstackProviderSpec

--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 	oc = exutil.NewCLI("openstack")
 
 	g.BeforeEach(func() {
-		ctx = context.TODO()
+		ctx = context.Background()
 
 		g.By("preparing a dynamic client")
 		cfg, err := e2e.LoadConfig()
@@ -119,7 +119,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 
 	// OCP 4.10: https://issues.redhat.com/browse/OSASINFRA-2507
 	g.It("creates Control plane nodes on separate hosts when serverGroupPolicy is anti-affinity", func() {
-		installConfig, err := installConfigFromCluster(oc.AdminKubeClient().CoreV1())
+		installConfig, err := installConfigFromCluster(ctx, oc.AdminKubeClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 		serverGroupPolicy := installConfig.ControlPlane.Platform.OpenStack.ServerGroupPolicy
 		if serverGroupPolicy != "anti-affinity" {
@@ -171,7 +171,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 
 	// OCP 4.10: https://issues.redhat.com/browse/OSASINFRA-2570
 	g.It("creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity", func() {
-		installConfig, err := installConfigFromCluster(oc.AdminKubeClient().CoreV1())
+		installConfig, err := installConfigFromCluster(ctx, oc.AdminKubeClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
 		serverGroupPolicy := installConfig.Compute[0].Platform.OpenStack.ServerGroupPolicy
 		if serverGroupPolicy != "anti-affinity" {
@@ -238,10 +238,10 @@ type installConfig struct {
 	} `yaml:"compute"`
 }
 
-func installConfigFromCluster(client clientcorev1.ConfigMapsGetter) (installConfig, error) {
+func installConfigFromCluster(ctx context.Context, client clientcorev1.ConfigMapsGetter) (installConfig, error) {
 	const installConfigName = "cluster-config-v1"
 
-	cm, err := client.ConfigMaps("kube-system").Get(context.Background(), installConfigName, metav1.GetOptions{})
+	cm, err := client.ConfigMaps("kube-system").Get(ctx, installConfigName, metav1.GetOptions{})
 	if err != nil {
 		return installConfig{}, err
 	}

--- a/test/extended/openstack/utils.go
+++ b/test/extended/openstack/utils.go
@@ -55,27 +55,27 @@ func RandomSuffix() string {
 	return strconv.Itoa(rand.Intn(10000))
 }
 
-func GetKuryrNetwork(clientSet *kubernetes.Clientset, namespace string) (KuryrNetwork, error) {
+func GetKuryrNetwork(ctx context.Context, clientSet *kubernetes.Clientset, namespace string) (KuryrNetwork, error) {
 	//TODO(itzikb): Replace a direct call to the API by extending the ClientSet
 	knetworkPath := fmt.Sprintf("/apis/openstack.org/v1/namespaces/%s/kuryrnetworks/%s", namespace, namespace)
 	data, err := clientSet.RESTClient().
 		Get().
 		AbsPath(knetworkPath).
-		DoRaw(context.TODO())
+		DoRaw(ctx)
 	var kn KuryrNetwork
 	json.Unmarshal(data, &kn)
 	return kn, err
 }
 
-func GetSubnetIDfromKuryrNetwork(clientSet *kubernetes.Clientset, namespace string) (string, error) {
-	kn, err := GetKuryrNetwork(clientSet, namespace)
+func GetSubnetIDfromKuryrNetwork(ctx context.Context, clientSet *kubernetes.Clientset, namespace string) (string, error) {
+	kn, err := GetKuryrNetwork(ctx, clientSet, namespace)
 	if err != nil {
 		return "", err
 	}
 	return kn.Status.SubnetID, nil
 }
 
-func CreateNamespace(clientSet *kubernetes.Clientset, baseName string, privileged bool) *v1.Namespace {
+func CreateNamespace(ctx context.Context, clientSet *kubernetes.Clientset, baseName string, privileged bool) *v1.Namespace {
 	nsName := fmt.Sprintf("%v-%v", baseName, RandomSuffix())
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,7 +88,7 @@ func CreateNamespace(clientSet *kubernetes.Clientset, baseName string, privilege
 			"security.openshift.io/scc.podSecurityLabelSync": "false",
 		}
 	}
-	_, err := clientSet.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := clientSet.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		e2e.Failf("unable to create namespace %v: %v", ns.Name, err)
 		return nil
@@ -97,14 +97,14 @@ func CreateNamespace(clientSet *kubernetes.Clientset, baseName string, privilege
 
 	return ns
 }
-func DeleteNamespace(clientSet *kubernetes.Clientset, ns *v1.Namespace) {
-	err := clientSet.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{})
+func DeleteNamespace(ctx context.Context, clientSet *kubernetes.Clientset, ns *v1.Namespace) {
+	err := clientSet.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
 	if err != nil {
 		e2e.Failf("unable to delete namespace %v: %v", ns.Name, err)
 	}
 }
 
-func CreatePod(clientSet *kubernetes.Clientset, nsName string, baseName string, hostNetwork bool, command []string) (*v1.Pod, error) {
+func CreatePod(ctx context.Context, clientSet *kubernetes.Clientset, nsName string, baseName string, hostNetwork bool, command []string) (*v1.Pod, error) {
 	podName := fmt.Sprintf("%v-%v", baseName, RandomSuffix())
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +121,7 @@ func CreatePod(clientSet *kubernetes.Clientset, nsName string, baseName string, 
 			HostNetwork: hostNetwork,
 		},
 	}
-	p, err := clientSet.CoreV1().Pods(nsName).Create(context.TODO(), pod, metav1.CreateOptions{})
+	p, err := clientSet.CoreV1().Pods(nsName).Create(ctx, pod, metav1.CreateOptions{})
 	if err == nil {
 		err = e2epod.WaitTimeoutForPodReadyInNamespace(clientSet, p.Name, nsName, e2e.PodStartShortTimeout)
 	}
@@ -150,7 +150,7 @@ func difference(a []string, b []string) []string {
 	return diff
 }
 
-func GetMachinesetRetry(client runtimeclient.Client, ms *machinev1.MachineSet, shouldExist bool) error {
+func GetMachinesetRetry(ctx context.Context, client runtimeclient.Client, ms *machinev1.MachineSet, shouldExist bool) error {
 	var err error
 	const maxRetries = 5
 	const delay = 10
@@ -170,12 +170,12 @@ func GetMachinesetRetry(client runtimeclient.Client, ms *machinev1.MachineSet, s
 
 // return *ini.File from the 'key' section in the 'cmName' configMap of the specified 'namespace'.
 // oc get cm -n {{namespace}} {{cmName}} -o json | jq .data.{{key}}
-func getConfig(kubeClient kubernetes.Interface, namespace string, cmName string,
+func getConfig(ctx context.Context, kubeClient kubernetes.Interface, namespace string, cmName string,
 	key string) (*ini.File, error) {
 
 	var cfg *ini.File
 	cmClient := kubeClient.CoreV1().ConfigMaps(namespace)
-	config, err := cmClient.Get(context.TODO(), cmName, metav1.GetOptions{})
+	config, err := cmClient.Get(ctx, cmName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, err
 	}
@@ -204,8 +204,8 @@ func getPropertyValue(sectionName string, propertyName string, cfg *ini.File) (s
 	}
 }
 
-func getNetworkType(oc *exutil.CLI) (string, error) {
-	networks, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
+func getNetworkType(ctx context.Context, oc *exutil.CLI) (string, error) {
+	networks, err := oc.AdminConfigClient().ConfigV1().Networks().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Instrument the tests with a context.Context object, in preparation for rebase on libraries that increasingly use it for cancellation.