### PR TITLE
Read processed cloud.conf from ConfigMap

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -83,9 +83,9 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		g.By("Gathering cloud-provider-config")
 		cloudProviderConfig, err = getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-config",
-			"cloud-provider-config",
-			"config")
+			"openshift-cloud-controller-manager",
+			"cloud-conf",
+			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 	})


### PR DESCRIPTION
Tests were reading the openshift-config/cloud-provider-config ConfigMap to get the current cloud provider settings. This is the ConfigMap that te user can use to set his own settings. There are however also settings that CCMO injects and the actual cloud.conf is produced by combining these with user input.

This commit makes sure we read the ConfigMap at
openshift-cloud-controller-manager/cloud-conf which is the one actually fed to cloud-provider-openstack. This way tests can take OpenShift defaults into account.