### PR TITLE
OCPBUGS-18607: skip LB tests when cluster is behind a proxy

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,9 +65,8 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		}
 
 		// TODO revert once https://issues.redhat.com/browse/OSASINFRA-3079 is resolved
-		proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if proxy.Status.HTTPProxy != "" {
+		// For now, LoadBalancer tests are not applicable when the cluster is running behind a proxy.
+		if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
 			e2eskipper.Skipf("Test not applicable for proxy setup")
 		}
 


### PR DESCRIPTION
We have observed that LB tests don't behave well when the OCP cluster
runs behind a proxy, like it's the case for most of the clusters running
in our Mecha and NFV clouds.

We have coverage of these tests on other clouds (VH managed), so we can
skip these tests for now in this scenario.

In the future, we want to improve that and make it so some LB tests can
be run behind a proxy (e.g. the TCP ones).
