### PR TITLE
local-bd-etcd: fix CPMS

### DIFF
--- a/test/extended/openstack/local-bd-etcd.go
+++ b/test/extended/openstack/local-bd-etcd.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
@@ -10,8 +11,6 @@ import (
 	o "github.com/onsi/gomega"
 	"github.com/openshift/openstack-test/test/extended/openstack/machines"
 	"github.com/stretchr/objx"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -21,15 +20,15 @@ import (
 var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift cluster", func() {
 	defer g.GinkgoRecover()
 
-	const minEtcdDiskSizeGiB = 7
+	const minEtcdDiskSizeGiB = 10
 	const etcdBlockDeviceName = "etcd"
 
 	var computeClient *gophercloud.ServiceClient
 	var ctx context.Context
 	var dc dynamic.Interface
 	var controlPlaneFlavor string
-	var clusterCPMS objx.Map
 	var clientSet *kubernetes.Clientset
+	var cpmsProviderSpec objx.Map
 
 	checkEtcdDisk := func(machine objx.Map) error {
 		additionalBlockDevices := machine.Get("spec.providerSpec.value.additionalBlockDevices").ObjxMapSlice()
@@ -39,40 +38,17 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 
 		for _, blockDevice := range additionalBlockDevices {
 			if blockDevice.Get("name").String() == etcdBlockDeviceName {
-				if blockDevice.Get("sizeGiB").Int() < minEtcdDiskSizeGiB {
-					return fmt.Errorf("machine %q has an additional block device with size %d GiB, which is less than the minimum required %d GiB", machine.Get("metadata.name").String(), blockDevice.Get("sizeGiB").Int(), minEtcdDiskSizeGiB)
-				}
-				if blockDevice.Get("storage.type").String() != "Local" {
-					return fmt.Errorf("machine %q has an additional block device with storage type %q, which is not Local", machine.Get("metadata.name").String(), blockDevice.Get("storage.type").String())
-				}
+				sizeInt, _ := strconv.Atoi(blockDevice.Get("sizeGiB").String())
+				o.Expect(sizeInt).To(o.BeNumerically(">=", minEtcdDiskSizeGiB))
+				o.Expect(blockDevice.Get("storage.type").String()).To(o.Equal("Local"))
 				return nil
 			}
 		}
 		return fmt.Errorf("machine %q does not have an additional block device named %s", machine.Get("metadata.name").String(), etcdBlockDeviceName)
 	}
 
-	getControlPlaneMachineSets := func(ctx context.Context, dc dynamic.Interface) ([]objx.Map, error) {
-		mc := dc.Resource(schema.GroupVersionResource{
-			Group:    machineAPIGroup,
-			Version:  "v1",
-			Resource: "controlplanemachinesets",
-		}).Namespace(machineAPINamespace)
-		obj, err := mc.List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return nil, err
-		}
-		cpmsList := objx.Map(obj.UnstructuredContent()).Get("items").ObjxMapSlice()
-		if numCpms := len(cpmsList); numCpms != 1 {
-			return nil, fmt.Errorf("expected one CPMS, found %d", numCpms)
-		}
-		return cpmsList, nil
-	}
-
-	skipUnlessEtcdAdditionalBlockDevice := func(ctx context.Context, dc dynamic.Interface) {
-		controlPlaneMachineSets, err := getControlPlaneMachineSets(ctx, dc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		cpms := controlPlaneMachineSets[0]
-		additionalBlockDevices := cpms.Get("spec.template.spec.providerSpec.value.additionalBlockDevices").ObjxMapSlice()
+	skipUnlessEtcdAdditionalBlockDevice := func(cpms objx.Map) {
+		additionalBlockDevices := cpmsProviderSpec.Get("value.additionalBlockDevices").ObjxMapSlice()
 		if len(additionalBlockDevices) == 0 {
 			e2eskipper.Skipf("CPMS does not have additional block devices")
 		}
@@ -102,15 +78,21 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		skipUnlessMachineAPIOperator(ctx, dc, clientSet.CoreV1().Namespaces())
-		skipUnlessEtcdAdditionalBlockDevice(ctx, dc)
 
+		cpms, err := getControlPlaneMachineSet(ctx, dc)
+		if err != nil {
+			e2eskipper.Skipf("Failed to get control plane machine sets: %v", err)
+		}
+		cpmsProviderSpec = cpms.Get("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec").ObjxMap()
+
+		skipUnlessEtcdAdditionalBlockDevice(cpms)
 	})
 
 	g.It("runs with etcd on ephemeral local block device", func() {
 
 		g.By("checking that the control plane flavor has enough ephemeral storage")
 		{
-			controlPlaneFlavor = clusterCPMS.Get("spec.template.spec.providerSpec.value.flavor").String()
+			controlPlaneFlavor = cpmsProviderSpec.Get("value.flavor").String()
 			o.Expect(controlPlaneFlavor).NotTo(o.BeEmpty())
 			allPages, err := flavors.ListDetail(computeClient, flavors.ListOpts{}).AllPages()
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
* Re-use code from cpms.go
* Simplify error handling in cpms.go for errors out of getCPMS.
  It wasn't useful to count the number of CPMS, it'll always be zero
  when an error occurs.
* If an error is found when listing CPMS, just skip the test.
  We don't care how many CPMS are found, there is already a check
  in the function. This test can only function when one CPMS is found. OpenShift CPMS can only have 1 CPMS for now.
* Stop returning numCpms, we don't need to know at it should always
  be one, otherwise we return an error.
* Increase the size of the block device required for etcd. etcd grow to
  max 8GB, so let's have some window and require 10 minimum.