### PR TITLE
ingress: re-add proxy.Status.HTTPProxy check

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		// TODO revert once https://issues.redhat.com/browse/OSASINFRA-3079 is resolved
 		proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		if proxy.Status.HTTPProxy != "" {
+		if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" || proxy.Status.HTTPProxy != "" {
 			e2eskipper.Skipf("Test not applicable for proxy setup")
 		}
 


### PR DESCRIPTION
If a cluster is running in a disconnected environment (ie BYON), the LBs
can't be created because right now the tests rely on Floating-IPs, which
is not a resource we can use in a restricted network.

Re-adding the previous condition, aside of the new one to cover both
use-cases.
