### PR TITLE
Wait for machines to be deleted

### DIFF
--- a/test/extended/openstack/machine.go
+++ b/test/extended/openstack/machine.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -212,6 +213,30 @@ func skipUnlessMachineAPIOperator(ctx context.Context, dc dynamic.Interface, c c
 		return false, nil
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func getMachinesByPrefix(prefix string, ctx context.Context, dc dynamic.Interface) ([]objx.Map, error) {
+	var machinesList []objx.Map
+
+	machines, err := machines.List(ctx, dc)
+
+	for _, machine := range machines {
+		machineName := machine.Get("metadata.name").String()
+		if strings.HasPrefix(machineName, prefix) {
+			machinesList = append(machinesList, machine)
+		}
+	}
+	return machinesList, err
+}
+
+func getMachinesNames(machines []objx.Map) []string {
+	var machinesNames []string
+
+	for _, machine := range machines {
+		machineName := machine.Get("metadata.name").String()
+		machinesNames = append(machinesNames, machineName)
+	}
+	return machinesNames
 }
 
 func mapKeys[K comparable, V any](m map[K]V) (keys []K) {


### PR DESCRIPTION
In the following test "[Suite:openshift/openstack] Bugfix bz_2073398: [Serial] MachineSet scale-in does not leak OpenStack ports" we introduce a bogus machineset (One that should fail)

It's possible that after deleting a bogus machineset a machine in stuck in Deleting phase.
We are waiting for the machine to get created and after the machineset is deleted make sure the machine is deleted as well