### PR TITLE
Increase wait for CloudPrivateIPConfig to be assigned to the worker

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -430,7 +430,7 @@ func waitCloudPrivateIPConfigAssignedNode(ctx context.Context, cloudNetClientset
 			}
 		}
 		return false
-	}, "30s", "1s").Should(o.BeTrue(), "Timed out checking the assigned node '%s' in '%s' CloudPrivateIPConfig.", node, egressIP)
+	}, "300s", "1s").Should(o.BeTrue(), "Timed out checking the assigned node '%s' in '%s' CloudPrivateIPConfig.", node, egressIP)
 	return true, nil
 }
 


### PR DESCRIPTION
It's observed on OSP17.1 cloud that the assignation is taking around 2 minutes:
```
$ oc logs -n openshift-cloud-network-config-controller cloud-network-config-controller-d56565b7b-bsr9g -f 
[...]
I1129 10:52:39.077934       1 controller.go:182] Assigning key: 10.196.0.2 to cloud-private-ip-config workqueue
I1129 10:52:39.081931       1 cloudprivateipconfig_controller.go:357] CloudPrivateIPConfig: "10.196.0.2" will be added to node: "ostest-7p85x-worker-0-g5f5l"
I1129 10:52:39.088772       1 cloudprivateipconfig_controller.go:381] Adding finalizer to CloudPrivateIPConfig: "10.196.0.2"
I1129 10:52:39.088876       1 controller.go:182] Assigning key: 10.196.0.2 to cloud-private-ip-config workqueue
I1129 10:54:51.148195       1 openstack.go:760] Getting port lock for portID d7a58be8-c7f4-4061-95ed-f4a75c50eee2 and IP 10.196.0.2
```
Therefore, this patch increases the wait time to 5 minutes. Since this is active waiting, this change will not affect clouds that are behaving faster.