### PR TITLE
Adapt tests to ipv6primary dualstack cluster

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -73,6 +73,12 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 
 	g.It("attached to a floating IP should be kept after EgressIP node failover with OVN-Kubernetes NetworkType", func() {
 
+		dualstackIpv6Primary, err := isIpv6primaryDualStackCluster(ctx, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if dualstackIpv6Primary { //This test is covering and scenario that has no sense with ipv6 as there is no FIP/egressIP association.
+			e2eskipper.Skipf("Test not applicable for ipv6primary dualstack environments")
+		}
+
 		g.By("Getting the network type")
 		networkType, err := getNetworkType(ctx, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/openstack/utils.go
+++ b/test/extended/openstack/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net"
 	"reflect"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	framework "github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
@@ -216,6 +218,54 @@ func getNetworkType(ctx context.Context, oc *exutil.CLI) (string, error) {
 	return networkType, nil
 }
 
+// Check the cluster networks and returns true if it finds one ipv4 and one ipv6 network there.
+func isDualStackCluster(clusterNetwork []configv1.ClusterNetworkEntry) (bool, error) {
+	ipv4Found := false
+	ipv6Found := false
+
+	for _, network := range clusterNetwork {
+		ip, _, err := net.ParseCIDR(network.CIDR)
+		if err != nil {
+			return false, err
+		}
+		e2e.Logf("Detected cluster network: %q", ip.String())
+		if !ipv4Found {
+			ipv4Found = isIpv4(ip.String())
+		}
+		if !ipv6Found {
+			ipv6Found = isIpv6(ip.String())
+		}
+	}
+	return (ipv4Found && ipv6Found), nil
+}
+
+// Check if it is a dualstack cluster and the first cluster network technology. Returns true if it is ipv6.
+func isIpv6primaryDualStackCluster(ctx context.Context, oc *exutil.CLI) (bool, error) {
+
+	networks, err := oc.AdminConfigClient().ConfigV1().Networks().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	dualstack, err := isDualStackCluster(networks.Status.ClusterNetwork)
+	if err != nil {
+		return false, err
+	}
+	if dualstack {
+		if err != nil {
+			return false, err
+		}
+		primaryNetwork := networks.Status.ClusterNetwork[0]
+		ip, _, err := net.ParseCIDR(primaryNetwork.CIDR)
+		if err != nil {
+			return false, err
+		}
+		if isIpv6(ip.String()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func getMaxOctaviaAPIVersion(client *gophercloud.ServiceClient) (*semver.Version, error) {
 	allPages, err := apiversions.List(client).AllPages()
 	if err != nil {
@@ -331,4 +381,26 @@ func conditionsMatchExpected(expected, actual map[string]string) bool {
 		}
 	}
 	return reflect.DeepEqual(expected, filtered)
+}
+
+// isIpv6 returns true if the ip is ipv6
+func isIpv6(ip string) bool {
+	ipv6 := false
+
+	netIP := net.ParseIP(ip)
+	if netIP != nil && netIP.To4() == nil {
+		ipv6 = true
+	}
+	return ipv6
+}
+
+// isIpv4 returns true if the ip is ipv4
+func isIpv4(ip string) bool {
+	ipv4 := false
+
+	netIP := net.ParseIP(ip)
+	if netIP != nil && netIP.To4() != nil {
+		ipv4 = true
+	}
+	return ipv4
 }


### PR DESCRIPTION
[KURYRQE-1414](https://issues.redhat.com//browse/KURYRQE-1414)

While running openstack-test in ipv6primary dualstack cluster, there are some tests that are not passing.

This patch performs the needed actions to make those tests available in both ipv4 and ipv6 primary dualstack cluster.