### PR TITLE
OCPBUGS-23352: Fix machineset machine role test

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -23,8 +23,6 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack] MachineSet ProviderSpec template is correctly applied to Machines": "",
 
-	"[sig-installer][Suite:openshift/openstack] MachineSet have role worker": "",
-
 	"[sig-installer][Suite:openshift/openstack] MachineSet replica number corresponds to the number of Machines": "",
 
 	"[sig-installer][Suite:openshift/openstack] The OpenShift cluster runs with etcd on ephemeral local block device": "",


### PR DESCRIPTION
The test was asserting that all MachineSets must label their machines as workers, which is not valid in a variety of situations. For example, we document the creation of 'infra' nodes, but as this is user-controlled data there are no constraints on what this value might be. We remove this test as there is no useful assertion we can make here.

Instead we assert that all machines get the labels from their machineset, which is consistent with the existing machineset machine test.