### PR TITLE
Fix typo on egressIPv6 test

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -256,7 +256,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		e2e.Logf("Found '%s' free IP address in the EgressIP network in Openstack", egressIPAddrStr)
 
 		g.By("Create egressIP resource in openshift")
-		egressIPname := "egress-ip"
+		egressIPname := "egress-ipv6"
 		err = createEgressIpResource(oc, egressIPname, egressIPAddrStr, "app: egress")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer oc.AsAdmin().Run("delete").Args("egressip", egressIPname).Execute()


### PR DESCRIPTION
Same egressIP object with same name can happen when running the whole test suite. In such a case, the test fails because it is already finding an egressIP called "egressip". This fix resolves that.