### PR TITLE
Skip infra nodes on egressIP tests

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -63,7 +63,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 
 		g.By("Getting the worker node list")
 		workerNodeList, err = clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker",
+			LabelSelector: "node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=",
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})


### PR DESCRIPTION
Observed in D/S CI, when infra nodes are present the infra nodes match the condition because it contains both labels:

    node-role.kubernetes.io/infra: ""
    node-role.kubernetes.io/worker: ""

However, infra nodes do not contain the annotation:

  cloud.network.openshift.io/egress-ipconfig

So that, the testcase is failing.

This fix is filtering by nodes including the worker label and not the infra annotation.