### PR TITLE
Add cinder test using default storageClass

### DIFF
--- a/test/extended/openstack/utils.go
+++ b/test/extended/openstack/utils.go
@@ -197,7 +197,8 @@ func GetSharesFromName(ctx context.Context, client *gophercloud.ServiceClient, s
 	return shares, nil
 }
 
-func FindStorageClassByProvider(oc *exutil.CLI, provisioner string) *storagev1.StorageClass {
+// return storageClass with specific provisioner. If seek_default is true, it will look also for the default annotation.
+func FindStorageClassByProvider(oc *exutil.CLI, provisioner string, seek_default bool) *storagev1.StorageClass {
 	scList, err := oc.AdminKubeClient().StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -208,7 +209,16 @@ func FindStorageClassByProvider(oc *exutil.CLI, provisioner string) *storagev1.S
 	}
 	for _, sc := range scList.Items {
 		if sc.Provisioner == provisioner {
-			return &sc
+			if seek_default {
+				val, ok := sc.GetAnnotations()["storageclass.kubernetes.io/is-default-class"]
+				// if we're explicitly looking for a default, the annotation must exist
+				if ok && val == "true" {
+					return &sc
+				}
+			} else {
+				// if we're not looking for a default, simply return the first result
+				return &sc
+			}
 		}
 	}
 	e2e.Logf("no default storage class found")

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -35,6 +35,8 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes on separate hosts when serverGroupPolicy is anti-affinity": "",
 
+	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should create a cinder volume when using cinder default storage class": "",
+
 	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should create a manila share when using manila storage class": "",
 
 	"[sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should follow PVC specs during resizing for prometheus": "",


### PR DESCRIPTION
This test uses the default cinder storageClass to create and use a PVC and covers https://issues.redhat.com/browse/OCPBUGS-30951 on multiAZ scenarios.