### PR TITLE
Remove Infra nodes from workers list

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -375,7 +375,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				g.By("Creating Openshift deployment")
 				labels := map[string]string{"app": "lb-etplocal-dep"}
 				workerNodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-					LabelSelector: "node-role.kubernetes.io/worker",
+					LabelSelector: "node-role.kubernetes.io/worker,!node-role.kubernetes.io/infra",
 				})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				replicas := len(workerNodeList.Items)


### PR DESCRIPTION
The following test create a deployment with number of pods equals to number of workers.
In a setup with Infra nodes this cause pods to be in pending state because Infra nodes are counted as workers. 
This patch removes the Infra nodes from the workers nodes list

```
"[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on TCP Amphora LoadBalancer when a TCP svc with monitors and ETP:Local is created on Openshift"
"[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on UDP Amphora LoadBalancer when a UDP svc with monitors and ETP:Local is created on Openshift"
```