### PR TITLE
Adapt etcd-to-ephemeral test

### DIFF
--- a/test/extended/openstack/local-bd-etcd.go
+++ b/test/extended/openstack/local-bd-etcd.go
@@ -1,17 +1,17 @@
 package openstack
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	mcv1client "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	"github.com/openshift/openstack-test/test/extended/openstack/client"
-	"github.com/openshift/openstack-test/test/extended/openstack/machines"
+	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/stretchr/objx"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -22,44 +22,21 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 	defer g.GinkgoRecover()
 
 	const minEtcdDiskSizeGiB = 10
-	const etcdBlockDeviceName = "etcd"
+	const blockDevicePath = "/dev/vdb"
 
+	oc := exutil.NewCLI("openstack")
 	var computeClient *gophercloud.ServiceClient
 	var dc dynamic.Interface
+	var mcClient *mcv1client.Clientset
 	var controlPlaneFlavor string
 	var clientSet *kubernetes.Clientset
 	var cpmsProviderSpec objx.Map
+	var masterNodeList *v1.NodeList
 
-	checkEtcdDisk := func(machine objx.Map) error {
-		additionalBlockDevices := machine.Get("spec.providerSpec.value.additionalBlockDevices").ObjxMapSlice()
-		if len(additionalBlockDevices) == 0 {
-			return fmt.Errorf("machine %q does not have additional block devices", machine.Get("metadata.name").String())
-		}
-
-		for _, blockDevice := range additionalBlockDevices {
-			if blockDevice.Get("name").String() == etcdBlockDeviceName {
-				sizeInt, _ := strconv.Atoi(blockDevice.Get("sizeGiB").String())
-				o.Expect(sizeInt).To(o.BeNumerically(">=", minEtcdDiskSizeGiB))
-				o.Expect(blockDevice.Get("storage.type").String()).To(o.Equal("Local"))
-				return nil
-			}
-		}
-		return fmt.Errorf("machine %q does not have an additional block device named %s", machine.Get("metadata.name").String(), etcdBlockDeviceName)
-	}
-
-	skipUnlessEtcdAdditionalBlockDevice := func(cpms objx.Map) {
-		additionalBlockDevices := cpmsProviderSpec.Get("value.additionalBlockDevices").ObjxMapSlice()
-		if len(additionalBlockDevices) == 0 {
-			e2eskipper.Skipf("CPMS does not have additional block devices")
-		}
-		var etcdDiskFound bool
-		for _, blockDevice := range additionalBlockDevices {
-			if blockDevice.Get("name").String() == etcdBlockDeviceName {
-				etcdDiskFound = true
-			}
-		}
-		if !etcdDiskFound {
-			e2eskipper.Skipf("CPMS does not have an additional block device named %s", etcdBlockDeviceName)
+	skipUnlessMachineConfigIsPresent := func(mcName string, ctx g.SpecContext) {
+		_, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+		if err != nil {
+			e2eskipper.Skipf("The expected machineConfig with name %s is not installed - Skipping. Error msg: %v", mcName, err)
 		}
 	}
 
@@ -69,6 +46,9 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 		o.Expect(err).NotTo(o.HaveOccurred())
 		dc, err = dynamic.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		mcClient, err = mcv1client.NewForConfig(cfg)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		clientSet, err = e2e.LoadClientset()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -77,6 +57,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		skipUnlessMachineAPIOperator(ctx, dc, clientSet.CoreV1().Namespaces())
+		skipUnlessMachineConfigIsPresent("98-var-lib-etcd", ctx)
 
 		cpms, err := getControlPlaneMachineSet(ctx, dc)
 		if err != nil {
@@ -84,7 +65,10 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 		}
 		cpmsProviderSpec = cpms.Get("spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec").ObjxMap()
 
-		skipUnlessEtcdAdditionalBlockDevice(cpms)
+		masterNodeList, err = clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/master",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.It("runs with etcd on ephemeral local block device", func(ctx g.SpecContext) {
@@ -104,17 +88,13 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenShift clu
 				}
 			}
 		}
-
-		g.By("checking that control plane machines have the additional ephemeral disk for etcd")
-		{
-			controlPlaneMachines, err := machines.List(ctx, dc, machines.ByRole("master"))
+		g.By("checking that the disk is succesfully mounted on the masters")
+		for _, item := range masterNodeList.Items {
+			out, err := oc.SetNamespace("default").AsAdmin().Run("debug").Args("node/"+item.Name,
+				"--", "chroot", "/host", "lsblk", blockDevicePath).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(controlPlaneMachines)).To(o.Equal(3))
-
-			for _, cpMachine := range controlPlaneMachines {
-				o.Expect(checkEtcdDisk(cpMachine)).To(o.Succeed())
-			}
+			o.Expect(out).To(o.ContainSubstring("/var/lib/etcd"),
+				"%s: Ephemeral disk is not mounted on 'var/lib/etcd' as expected:\n%q\n", item.Name, out)
 		}
-
 	})
 })


### PR DESCRIPTION
https://issues.redhat.com/browse/SOSQE-1875

It's observed that it's not needed to include the AdditionalBlockDevice in the CPMS object to have the ephemeral volume available to be mounted. That makes the test invalid. This patch is updating it so it properly test the feature.