### PR TITLE
Fetch a cluster external network for egress ip

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -159,10 +159,17 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		g.By("Checking that the allowed_addresses_pairs are properly updated for the workers in the Openstack before failover")
 		checkAllowedAddressesPairs(networkClient, primaryWorker, secondaryWorker, egressIPAddrStr, machineNetworkID)
 
-		g.By("Creating a FIP in Openstack")
-		var fip *floatingips.FloatingIP
-		externalNetworkId, err := GetFloatingNetworkID(networkClient)
+		g.By("Fetching an external network for the cluster")
+		cloudProviderConfig, err := getConfig(ctx,
+			oc.AdminKubeClient(),
+			"openshift-cloud-controller-manager",
+			"cloud-conf",
+			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
+		var fip *floatingips.FloatingIP
+		externalNetworkId, err := GetFloatingNetworkID(networkClient, cloudProviderConfig)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Creating a FIP in Openstack")
 		fip, err = floatingips.Create(networkClient, floatingips.CreateOpts{FloatingNetworkID: externalNetworkId}).Extract()
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating FIP using discovered floatingNetwork ID '%s'", externalNetworkId)
 		e2e.Logf("The FIP '%s' has been created in Openstack", fip.FloatingIP)

--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -158,7 +158,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				o.Expect(pool.Protocol).Should(o.Equal(string(protocolUnderTest)), "Unexpected protocol on Openstack LoadBalancer Pool: %q", pool.Name)
 				//Set as OFFLINE in vexxhost despite the lb is operative
 				//o.Expect(pool.OperatingStatus).Should(o.Equal("ONLINE"), "Unexpected Operating Status on Openstack Pool: %q", pool.Name)
-				lbMethod, err := getClusterLoadBalancerSetting("lb-method", cloudProviderConfig)
+				lbMethod, err := GetClusterLoadBalancerSetting("lb-method", cloudProviderConfig)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(strings.ToLower(pool.LBMethod)).Should(o.Equal(lbMethod), "Unexpected LBMethod on Openstack Pool: %q", strings.ToLower(pool.LBMethod))
 				nodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -194,7 +194,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 			skipIfNotLbProvider(lbProviderUnderTest, cloudProviderConfig)
 
 			g.By("Checking cluster configuration")
-			setting, err := getClusterLoadBalancerSetting("max-shared-lb", cloudProviderConfig)
+			setting, err := GetClusterLoadBalancerSetting("max-shared-lb", cloudProviderConfig)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			maxSharedLb, err := strconv.Atoi(setting)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -281,7 +281,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 			skipIfNotLbProvider(lbProviderUnderTest, cloudProviderConfig)
 
 			g.By("Checking cluster configuration")
-			setting, err := getClusterLoadBalancerSetting("max-shared-lb", cloudProviderConfig)
+			setting, err := GetClusterLoadBalancerSetting("max-shared-lb", cloudProviderConfig)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			maxSharedLb, err := strconv.Atoi(setting)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -450,7 +450,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				o.Expect(monitor.Delay).Should(o.Equal(monitorDelay), "Unexpected healthmonitor delay on Openstack LoadBalancer Pool: %q", pool.Name)
 				o.Expect(monitor.Timeout).Should(o.Equal(monitorTimeout), "Unexpected healthmonitor timeout on Openstack LoadBalancer Pool: %q", pool.Name)
 				o.Expect(monitor.MaxRetries).Should(o.Equal(monitorMaxRetries), "Unexpected healthmonitor MaxRetries on Openstack LoadBalancer Pool: %q", pool.Name)
-				lbMethod, err := getClusterLoadBalancerSetting("lb-method", cloudProviderConfig)
+				lbMethod, err := GetClusterLoadBalancerSetting("lb-method", cloudProviderConfig)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(strings.ToLower(pool.LBMethod)).Should(o.Equal(lbMethod), "Unexpected LBMethod on Openstack Pool: %q", pool.LBMethod)
 
@@ -497,19 +497,15 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 
 			g.By("Create FIP to be used on the subsequent LoadBalancer Service")
 			var fip *floatingips.FloatingIP
-			// Use network configured on cloud-provider-config if any
-			configuredNetworkId, _ := getClusterLoadBalancerSetting("floating-network-id", cloudProviderConfig)
-			configuredSubnetId, _ := getClusterLoadBalancerSetting("floating-subnet-id", cloudProviderConfig)
-			if configuredNetworkId != "" {
-				fip, err = floatingips.Create(networkClient, floatingips.CreateOpts{FloatingNetworkID: configuredNetworkId, SubnetID: configuredSubnetId}).Extract()
-				o.Expect(err).NotTo(o.HaveOccurred(), "error creating FIP using IDs configured on the OCP cluster. Network-id: %s. Subnet-id: %s", configuredNetworkId, configuredSubnetId)
-			} else {
-				// If not, discover the first FloatingNetwork existing on OSP
-				foundNetworkId, err := GetFloatingNetworkID(networkClient)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				fip, err = floatingips.Create(networkClient, floatingips.CreateOpts{FloatingNetworkID: foundNetworkId}).Extract()
-				o.Expect(err).NotTo(o.HaveOccurred(), "error creating FIP using discovered floatingNetwork ID %s", foundNetworkId)
+			foundNetworkId, err := GetFloatingNetworkID(networkClient, cloudProviderConfig)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			createOpts := floatingips.CreateOpts{FloatingNetworkID: foundNetworkId}
+			configuredSubnetId, _ := GetClusterLoadBalancerSetting("floating-subnet-id", cloudProviderConfig)
+			if configuredSubnetId != "" {
+				createOpts.SubnetID = configuredSubnetId
 			}
+			fip, err = floatingips.Create(networkClient, createOpts).Extract()
+			o.Expect(err).NotTo(o.HaveOccurred(), "error creating FIP using IDs configured on the OCP cluster. Network-id: %s. Subnet-id: %s", foundNetworkId, configuredSubnetId)
 			g.By(fmt.Sprintf("FIP created: %s", fip.FloatingIP))
 			defer floatingips.Delete(networkClient, fip.ID)
 
@@ -789,31 +785,11 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 // Check ini.File from cloudProviderConfig and skip the tests if lb-provider is not matching the expected value
 func skipIfNotLbProvider(expectedLbProvider string, ini *ini.File) {
 
-	foundLbProvider, err := getClusterLoadBalancerSetting("lb-provider", ini)
+	foundLbProvider, err := GetClusterLoadBalancerSetting("lb-provider", ini)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	if foundLbProvider != strings.ToLower(expectedLbProvider) {
 		e2eskipper.Skipf("Test not applicable for LoadBalancer provider different than %s. Cluster is configured with %q", expectedLbProvider, foundLbProvider)
 	}
-}
-
-// get the LoadBalancer setting based on the provided CloudProviderConfig INI file and the default values
-func getClusterLoadBalancerSetting(setting string, config *ini.File) (string, error) {
-
-	defaultLoadBalancerSettings := map[string]string{
-		"lb-provider":   "amphora",
-		"lb-method":     "round_robin",
-		"max-shared-lb": "2",
-	}
-
-	result, err := getPropertyValue("LoadBalancer", setting, config)
-	if err != nil || result == "#UNDEFINED#" {
-		if _, ok := defaultLoadBalancerSettings[setting]; !ok {
-			return "", fmt.Errorf("%q setting value not found and default is unknown", setting)
-		}
-		result = defaultLoadBalancerSettings[setting]
-		e2e.Logf("%q is not set on LoadBalancer section in cloud-provider-config, considering default value %q", setting, result)
-	}
-	return strings.ToLower(result), nil
 }
 
 // Return the FloatingIP assigned to a provided IP and return error if it is not found.

--- a/test/extended/openstack/utils.go
+++ b/test/extended/openstack/utils.go
@@ -472,7 +472,11 @@ func IsOctaviaVersionGreaterThanOrEqual(client *gophercloud.ServiceClient, const
 }
 
 // GetFloatingNetworkID returns a floating network ID.
-func GetFloatingNetworkID(client *gophercloud.ServiceClient) (string, error) {
+func GetFloatingNetworkID(client *gophercloud.ServiceClient, cloudProviderConfig *ini.File) (string, error) {
+	configuredNetworkId, _ := GetClusterLoadBalancerSetting("floating-network-id", cloudProviderConfig)
+	if configuredNetworkId != "" {
+		return configuredNetworkId, nil
+	}
 	type NetworkWithExternalExt struct {
 		networks.Network
 		external.NetworkExternalExt
@@ -561,4 +565,24 @@ func isIpv4(ip string) bool {
 		ipv4 = true
 	}
 	return ipv4
+}
+
+// get the LoadBalancer setting based on the provided CloudProviderConfig INI file and the default values
+func GetClusterLoadBalancerSetting(setting string, config *ini.File) (string, error) {
+
+	defaultLoadBalancerSettings := map[string]string{
+		"lb-provider":   "amphora",
+		"lb-method":     "round_robin",
+		"max-shared-lb": "2",
+	}
+
+	result, err := getPropertyValue("LoadBalancer", setting, config)
+	if err != nil || result == "#UNDEFINED#" {
+		if _, ok := defaultLoadBalancerSettings[setting]; !ok {
+			return "", fmt.Errorf("%q setting value not found and default is unknown", setting)
+		}
+		result = defaultLoadBalancerSettings[setting]
+		e2e.Logf("%q is not set on LoadBalancer section in cloud-provider-config, considering default value %q", setting, result)
+	}
+	return strings.ToLower(result), nil
 }


### PR DESCRIPTION
When trying to create a Floating IP for the egress IP test, we shouldn't try to fetch any external network present in the OSP as some might not be reachable from the OCP Machines. This commit fixed the issue by fetching an external network configured for the Load Balancer. This test is skipped for proxy installations, so we won't hit any issues due to non existency of the external network config.