### PR TITLE
OCPBUGS-42498: Fetch a cluster external network for egress ip

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -180,10 +180,17 @@ spec:
 		g.By("Checking that the allowed_addresses_pairs are properly updated for the workers in the Openstack before failover")
 		checkAllowedAddressesPairs(networkClient, primaryWorker, secondaryWorker, egressIPAddrStr, machineNetworkID)
 
-		g.By("Creating a FIP in Openstack")
-		var fip *floatingips.FloatingIP
-		externalNetworkId, err := GetFloatingNetworkID(networkClient)
+		g.By("Fetching an external network for the cluster")
+		cloudProviderConfig, err := getConfig(ctx,
+			oc.AdminKubeClient(),
+			"openshift-cloud-controller-manager",
+			"cloud-conf",
+			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
+		var fip *floatingips.FloatingIP
+		externalNetworkId, err := GetFloatingNetworkID(networkClient, cloudProviderConfig)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Creating a FIP in Openstack")
 		fip, err = floatingips.Create(networkClient, floatingips.CreateOpts{FloatingNetworkID: externalNetworkId}).Extract()
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating FIP using discovered floatingNetwork ID '%s'", externalNetworkId)
 		e2e.Logf("The FIP '%s' has been created in Openstack", fip.FloatingIP)


### PR DESCRIPTION
When trying to create a Floating IP for the egress IP test, we shouldn't try to fetch any external network present in the OSP as some might not be reachable from the OCP Machines. This commit fixed the issue by fetching an external network configured for the Load Balancer. This test is skipped for proxy installations, so we won't hit any issues due to non existency of the external network config.