### PR TITLE
Adapt egressIP test to dualstack

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -73,6 +73,12 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 
 	g.It("attached to a floating IP should be kept after EgressIP node failover with OVN-Kubernetes NetworkType", func() {
 
+		dualstackIpv6Primary, err := isIpv6primaryDualStackCluster(ctx, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if dualstackIpv6Primary { //This test is covering and scenario that has no sense with ipv6 as there is no FIP/egressIP association.
+			e2eskipper.Skipf("Test not applicable for ipv6primary dualstack environments")
+		}
+
 		g.By("Getting the network type")
 		networkType, err := getNetworkType(ctx, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -45,6 +45,8 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack][egressip] An egressIP attached to a floating IP should be kept after EgressIP node failover with OVN-Kubernetes NetworkType": "",
 
+	"[sig-installer][Suite:openshift/openstack][egressip] An egressIP with IPv6 format should be created on dualstack cluster with OVN-Kubernetes NetworkType and dhcpv6-stateful mode": "",
+
 	"[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on TCP Amphora LoadBalancer when a TCP svc with monitors and ETP:Local is created on Openshift": "",
 
 	"[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on TCP OVN LoadBalancer when a TCP svc with monitors and ETP:Local is created on Openshift": "",


### PR DESCRIPTION
This PR backports the following two commits:

- First: [Adapt tests to ipv6primary dualstack cluster](https://github.com/openshift/openstack-test/commit/233f173b1c839115c1af5a02060464831cff0a6f#diff-3c085086ae67274b973d70d10a2e27a2d4947730b75e358271611784b2d9b181L639) - it's necessary since implements the `isDualStackCluster` function needed by the next commit
- Second: [Adapt egressIP test to dualstack](https://github.com/openshift/openstack-test/commit/262b49a30ea8e6f2476cca360869a508934a847b#diff-3a76652f8fdc480b9de47b0ac455ae7b62455a8c0072a7eda84c479115a0239fR205) - it's necessary as it adapts the `getEgressIPNetwork(primaryWorker)` to  `getEgressNetworkInfo(primaryWorker, "ipv4")` which returns the specific Port to be used and should help with the error seen in the dualstack jobs:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-shiftstack-ci-release-4.14-e2e-openstack-dualstack-techpreview/1849493935328595968