### PR TITLE
OCPBUGS-45132: Adapt tests to ssipv6

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -492,6 +492,11 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 			if dualstackIpv6Primary { //This test is covering and scenario that has no sense with ipv6 as there is no FIP/VIP association.
 				e2eskipper.Skipf("Test not applicable for ipv6primary dualstack environments")
 			}
+			singleStackIpv6, err := isSingleStackIpv6Cluster(ctx, oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if singleStackIpv6 { //This test is covering and scenario that has no sense with ipv6 as there is no FIP/VIP association.
+				e2eskipper.Skipf("Test not applicable for singleStack IPv6 environments")
+			}
 
 			g.By("Create FIP to be used on the subsequent LoadBalancer Service")
 			var fip *floatingips.FloatingIP
@@ -634,7 +639,9 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 			allowed_sourcerange := "9.9.9.9/32"
 			ipv6PrimaryDualStack, err := isIpv6primaryDualStackCluster(ctx, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			if ipv6PrimaryDualStack {
+			singleStackIpv6, err := isSingleStackIpv6Cluster(ctx, oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if ipv6PrimaryDualStack || singleStackIpv6 {
 				allowed_sourcerange = "2001:db8:2222:5555::/64"
 			}
 

--- a/test/extended/openstack/utils.go
+++ b/test/extended/openstack/utils.go
@@ -425,6 +425,24 @@ func isDualStackCluster(clusterNetwork []configv1.ClusterNetworkEntry) (bool, er
 	return (ipv4Found && ipv6Found), nil
 }
 
+func isSingleStackIpv6Cluster(ctx context.Context, oc *exutil.CLI) (bool, error) {
+
+	networks, err := oc.AdminConfigClient().ConfigV1().Networks().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if len(networks.Status.ClusterNetwork) == 1 {
+		ip, _, err := net.ParseCIDR(networks.Status.ClusterNetwork[0].CIDR)
+		if err != nil {
+			return false, err
+		}
+		if isIpv6(ip.String()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Check if it is a dualstack cluster and the first cluster network technology. Returns true if it is ipv6.
 func isIpv6primaryDualStackCluster(ctx context.Context, oc *exutil.CLI) (bool, error) {
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -53,7 +53,7 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack][egressip] An egressIP attached to a floating IP should be kept after EgressIP node failover with OVN-Kubernetes NetworkType": "",
 
-	"[sig-installer][Suite:openshift/openstack][egressip] An egressIP with IPv6 format should be created on dualstack cluster with OVN-Kubernetes NetworkType and dhcpv6-stateful mode": "",
+	"[sig-installer][Suite:openshift/openstack][egressip] An egressIP with IPv6 format should be created on dualstack or ssipv6 cluster with OVN-Kubernetes NetworkType and dhcpv6-stateful mode": "",
 
 	"[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on TCP Amphora LoadBalancer when a TCP svc with monitors and ETP:Local is created on Openshift": "",
 


### PR DESCRIPTION
Changes needed to properly test a ssipv6 shiftstack cluster