### PR TITLE
[release 4.15] Check manila Storage class before checking manila endp…

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/requests.go
@@ -1,0 +1,219 @@
+package sharetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToShareTypeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a ShareType. This object is
+// passed to the sharetypes.Create function. For more information about
+// these parameters, see the ShareType object.
+type CreateOpts struct {
+	// The share type name
+	Name string `json:"name" required:"true"`
+	// Indicates whether a share type is publicly accessible
+	IsPublic bool `json:"os-share-type-access:is_public"`
+	// The extra specifications for the share type
+	ExtraSpecs ExtraSpecsOpts `json:"extra_specs" required:"true"`
+}
+
+// ExtraSpecsOpts represent the extra specifications that can be selected for a share type
+type ExtraSpecsOpts struct {
+	// An extra specification that defines the driver mode for share server, or storage, life cycle management
+	DriverHandlesShareServers bool `json:"driver_handles_share_servers" required:"true"`
+	// An extra specification that filters back ends by whether they do or do not support share snapshots
+	SnapshotSupport *bool `json:"snapshot_support,omitempty"`
+}
+
+// ToShareTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToShareTypeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "share_type")
+}
+
+// Create will create a new ShareType based on the values in CreateOpts. To
+// extract the ShareType object from the response, call the Extract method
+// on the CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToShareTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete the existing ShareType with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToShareTypeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing ShareTypes. It is passed to the
+// sharetypes.List function.
+type ListOpts struct {
+	// Select if public types, private types, or both should be listed
+	IsPublic string `q:"is_public"`
+}
+
+// ToShareTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToShareTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns ShareTypes optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToShareTypeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ShareTypePage{pagination.SinglePageBase(r)}
+	})
+}
+
+// GetDefault will retrieve the default ShareType.
+func GetDefault(client *gophercloud.ServiceClient) (r GetDefaultResult) {
+	resp, err := client.Get(getDefaultURL(client), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetExtraSpecs will retrieve the extra specifications for a given ShareType.
+func GetExtraSpecs(client *gophercloud.ServiceClient, id string) (r GetExtraSpecsResult) {
+	resp, err := client.Get(getExtraSpecsURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// SetExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// SetExtraSpecs request.
+type SetExtraSpecsOptsBuilder interface {
+	ToShareTypeSetExtraSpecsMap() (map[string]interface{}, error)
+}
+
+type SetExtraSpecsOpts struct {
+	// A list of all extra specifications to be added to a ShareType
+	ExtraSpecs map[string]interface{} `json:"extra_specs" required:"true"`
+}
+
+// ToShareTypeSetExtraSpecsMap assembles a request body based on the contents of a
+// SetExtraSpecsOpts.
+func (opts SetExtraSpecsOpts) ToShareTypeSetExtraSpecsMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+// SetExtraSpecs will set new specifications for a ShareType based on the values
+// in SetExtraSpecsOpts. To extract the extra specifications object from the response,
+// call the Extract method on the SetExtraSpecsResult.
+func SetExtraSpecs(client *gophercloud.ServiceClient, id string, opts SetExtraSpecsOptsBuilder) (r SetExtraSpecsResult) {
+	b, err := opts.ToShareTypeSetExtraSpecsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(setExtraSpecsURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UnsetExtraSpecs will unset an extra specification for an existing ShareType.
+func UnsetExtraSpecs(client *gophercloud.ServiceClient, id string, key string) (r UnsetExtraSpecsResult) {
+	resp, err := client.Delete(unsetExtraSpecsURL(client, id, key), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ShowAccess will show access details for an existing ShareType.
+func ShowAccess(client *gophercloud.ServiceClient, id string) (r ShowAccessResult) {
+	resp, err := client.Get(showAccessURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// AddAccessOptsBuilder allows extensions to add additional parameters to the
+// AddAccess
+type AddAccessOptsBuilder interface {
+	ToAddAccessMap() (map[string]interface{}, error)
+}
+
+type AccessOpts struct {
+	// The UUID of the project to which access to the share type is granted.
+	Project string `json:"project"`
+}
+
+// ToAddAccessMap assembles a request body based on the contents of a
+// AccessOpts.
+func (opts AccessOpts) ToAddAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "addProjectAccess")
+}
+
+// AddAccess will add access to a ShareType based on the values
+// in AccessOpts.
+func AddAccess(client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+	b, err := opts.ToAddAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(addAccessURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveAccessOptsBuilder allows extensions to add additional parameters to the
+// RemoveAccess
+type RemoveAccessOptsBuilder interface {
+	ToRemoveAccessMap() (map[string]interface{}, error)
+}
+
+// ToRemoveAccessMap assembles a request body based on the contents of a
+// AccessOpts.
+func (opts AccessOpts) ToRemoveAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "removeProjectAccess")
+}
+
+// RemoveAccess will remove access to a ShareType based on the values
+// in AccessOpts.
+func RemoveAccess(client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+	b, err := opts.ToRemoveAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := client.Post(removeAccessURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/results.go
@@ -1,0 +1,143 @@
+package sharetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ShareType contains all the information associated with an OpenStack
+// ShareType.
+type ShareType struct {
+	// The Share Type ID
+	ID string `json:"id"`
+	// The Share Type name
+	Name string `json:"name"`
+	// Indicates whether a share type is publicly accessible
+	IsPublic bool `json:"os-share-type-access:is_public"`
+	// The required extra specifications for the share type
+	RequiredExtraSpecs map[string]interface{} `json:"required_extra_specs"`
+	// The extra specifications for the share type
+	ExtraSpecs map[string]interface{} `json:"extra_specs"`
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the ShareType object out of the commonResult object.
+func (r commonResult) Extract() (*ShareType, error) {
+	var s struct {
+		ShareType *ShareType `json:"share_type"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ShareType, err
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ShareTypePage is a pagination.pager that is returned from a call to the List function.
+type ShareTypePage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no ShareTypes.
+func (r ShareTypePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	shareTypes, err := ExtractShareTypes(r)
+	return len(shareTypes) == 0, err
+}
+
+// ExtractShareTypes extracts and returns ShareTypes. It is used while
+// iterating over a sharetypes.List call.
+func ExtractShareTypes(r pagination.Page) ([]ShareType, error) {
+	var s struct {
+		ShareTypes []ShareType `json:"share_types"`
+	}
+	err := (r.(ShareTypePage)).ExtractInto(&s)
+	return s.ShareTypes, err
+}
+
+// GetDefaultResult contains the response body and error from a Get Default request.
+type GetDefaultResult struct {
+	commonResult
+}
+
+// ExtraSpecs contains all the information associated with extra specifications
+// for an Openstack ShareType.
+type ExtraSpecs map[string]interface{}
+
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the ExtraSpecs object out of the commonResult object.
+func (r extraSpecsResult) Extract() (ExtraSpecs, error) {
+	var s struct {
+		Specs ExtraSpecs `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Specs, err
+}
+
+// GetExtraSpecsResult contains the response body and error from a Get Extra Specs request.
+type GetExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// SetExtraSpecsResult contains the response body and error from a Set Extra Specs request.
+type SetExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// UnsetExtraSpecsResult contains the response body and error from a Unset Extra Specs request.
+type UnsetExtraSpecsResult struct {
+	gophercloud.ErrResult
+}
+
+// ShareTypeAccess contains all the information associated with an OpenStack
+// ShareTypeAccess.
+type ShareTypeAccess struct {
+	// The share type ID of the member.
+	ShareTypeID string `json:"share_type_id"`
+	// The UUID of the project for which access to the share type is granted.
+	ProjectID string `json:"project_id"`
+}
+
+type shareTypeAccessResult struct {
+	gophercloud.Result
+}
+
+// ShowAccessResult contains the response body and error from a Show access request.
+type ShowAccessResult struct {
+	shareTypeAccessResult
+}
+
+// Extract will get the ShareTypeAccess objects out of the shareTypeAccessResult object.
+func (r ShowAccessResult) Extract() ([]ShareTypeAccess, error) {
+	var s struct {
+		ShareTypeAccess []ShareTypeAccess `json:"share_type_access"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ShareTypeAccess, err
+}
+
+// AddAccessResult contains the response body and error from a Add Access request.
+type AddAccessResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveAccessResult contains the response body and error from a Remove Access request.
+type RemoveAccessResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes/urls.go
@@ -1,0 +1,43 @@
+package sharetypes
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return createURL(c)
+}
+
+func getDefaultURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types", "default")
+}
+
+func getExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "extra_specs")
+}
+
+func setExtraSpecsURL(c *gophercloud.ServiceClient, id string) string {
+	return getExtraSpecsURL(c, id)
+}
+
+func unsetExtraSpecsURL(c *gophercloud.ServiceClient, id string, key string) string {
+	return c.ServiceURL("types", id, "extra_specs", key)
+}
+
+func showAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "share_type_access")
+}
+
+func addAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id, "action")
+}
+
+func removeAccessURL(c *gophercloud.ServiceClient, id string) string {
+	return addAccessURL(c, id)
+}


### PR DESCRIPTION
Update the test "[sig-installer][Suite:openshift/openstack] The OpenStack platform on volume creation should create a manila share when using manila storage class "
If manila storage class doesn't exist - skip the test.
If it exists - check that the manila endpoint exists if not - fail