### PR TITLE
Test setting NoAllowedAddress for a network

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -11,6 +11,8 @@ var Annotations = map[string]string{
 
 	"[sig-installer][Suite:openshift/openstack] Bugfix bz_2073398: [Serial] MachineSet scale-in does not leak OpenStack ports": "",
 
+	"[sig-installer][Suite:openshift/openstack] Bugfix ocpbug_1765: [Serial] noAllowedAddressPairs on one port should not affect other ports": "",
+
 	"[sig-installer][Suite:openshift/openstack] ControlPlane MachineSet ProviderSpec template is correctly applied to Machines": "",
 
 	"[sig-installer][Suite:openshift/openstack] ControlPlane MachineSet has role master": "",


### PR DESCRIPTION
Make sure that when setting a noAloowedAddress for a network in a machine only the port for this network has the empty AllowedAddressPairs
It creates a new machineset with one replica based on an existing machineset and adding a network with NoAllowedAddressPairs set to true, then checks to see just only this port has an empty AllowedAddressPairs