### PR TITLE
Update monitor type check for TCP

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -452,7 +452,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(strings.ToLower(pool.LBMethod)).Should(o.Equal(lbMethod), "Unexpected LBMethod on Openstack Pool: %q", pool.LBMethod)
 
-				if monitor.Type == "UDP-CONNECT" {
+				if (monitor.Type == "UDP-CONNECT" && protocolUnderTest == v1.ProtocolUDP) || (monitor.Type == "TCP" && protocolUnderTest == v1.ProtocolTCP) {
 					o.Expect(waitUntilNmembersReady(ctx, loadBalancerClient, pool, int(replicas), "ONLINE")).NotTo(o.HaveOccurred(),
 						"Error waiting for %d members with ONLINE OperatingStatus", replicas)
 				} else if monitor.Type == "HTTP" {
@@ -460,6 +460,8 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 					// Therefore, the test cannot know when the the members are ready, so waiting 30 seconds for stability
 					e2e.Logf("monitor type is HTTP - Giving 30 seconds to let it calculate the ONLINE members")
 					time.Sleep(30 * time.Second)
+				} else {
+					e2e.Fail("Unexpected monitor type: " + monitor.Type)
 				}
 
 				g.By("accessing the service 100 times from outside and storing the name of the pods answering")


### PR DESCRIPTION
While running below test in RHOSO:

 "[sig-installer][Suite:openshift/openstack][lb][Serial] The Openstack platform should apply lb-method on TCP OVN LoadBalancer when a TCP svc with monitors and ETP:Local is created on Openshift"

It's observed that a new monitor type 'TCP' appears. Therefore, the function "waitUntilMembersReady" is not run and the test is sending the traffic before the LB is ready to be tested.

This change includes now the TCP monitor.Type for the TCP test and will also raise a proper fail if an unexpected monitor.Type is found.