### PR TITLE
Update ConfigMap to check the LB configuration

### DIFF
--- a/test/extended/openstack/dualstack.go
+++ b/test/extended/openstack/dualstack.go
@@ -70,8 +70,8 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		g.By("Gathering cloud-provider-config")
 		cloudProviderConfig, err = getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-cloud-controller-manager",
-			"cloud-conf",
+			"openshift-config",
+			"cloud-provider-config",
 			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -166,8 +166,8 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		g.By("Fetching an external network for the cluster")
 		cloudProviderConfig, err := getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-cloud-controller-manager",
-			"cloud-conf",
+			"openshift-config",
+			"cloud-provider-config",
 			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		var fip *floatingips.FloatingIP

--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -84,8 +84,8 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		g.By("Gathering cloud-provider-config")
 		cloudProviderConfig, err = getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-cloud-controller-manager",
-			"cloud-conf",
+			"openshift-config",
+			"cloud-provider-config",
 			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
The new config map is present also in hypershift clusters, so we can use both for the same purpose: gathering the LB config in the OCP cluster.