### PR TITLE
Adapt ConfigMap selection to Hosted vs regular OpenShift

### DIFF
--- a/test/extended/openstack/dualstack.go
+++ b/test/extended/openstack/dualstack.go
@@ -68,10 +68,21 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Gathering cloud-provider-config")
-		cloudProviderConfig, err = getConfig(ctx,
+		isHCP, err := IsHostedControlPlane(ctx, clientSet)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var configMapNameSpace, configMapName string
+		if isHCP {
+			configMapNameSpace = "openshift-config"
+			configMapName = "cloud-provider-config"
+		} else {
+			configMapNameSpace = "openshift-cloud-controller-manager"
+			configMapName = "cloud-conf"
+		}
+		cloudProviderConfig, err := getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-cloud-controller-manager",
-			"cloud-conf",
+			configMapNameSpace,
+			configMapName,
 			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -82,10 +82,22 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Gathering cloud-provider-config")
-		cloudProviderConfig, err = getConfig(ctx,
+		isHCP, err := IsHostedControlPlane(ctx, clientSet)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var configMapNameSpace, configMapName string
+		if isHCP {
+			configMapNameSpace = "openshift-config"
+			configMapName = "cloud-provider-config"
+		} else {
+			configMapNameSpace = "openshift-cloud-controller-manager"
+			configMapName = "cloud-conf"
+		}
+
+		cloudProviderConfig, err := getConfig(ctx,
 			oc.AdminKubeClient(),
-			"openshift-cloud-controller-manager",
-			"cloud-conf",
+			configMapNameSpace,
+			configMapName,
 			"cloud.conf")
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
- Adds HCP detection via ConfigMap label hypershift.openshift.io/managed
- Updates loadbalancers.go, egressip.go, and dualstack.go to dynamically choose the correct namespace and ConfigMap when loading cloud-provider config:
    - Hosted Control Plane clusters: openshift-config/cloud-provider-config
    - Regular OpenShift clusters: openshift-cloud-controller-manager/cloud-conf
- Adds shared utility functions to utils.go

Ensures tests work correctly across both cluster types.