### PR TITLE
OCPBUGS-55931: Fix noAllowedAddressPairs test

### DIFF
--- a/test/extended/openstack/machines/machines.go
+++ b/test/extended/openstack/machines/machines.go
@@ -67,3 +67,17 @@ func ByLabelRequirement(labelRequirement labels.Requirement) func(*metav1.ListOp
 		listOptions.LabelSelector = existingLabelSelector.Add(labelRequirement).String()
 	}
 }
+
+func Get(ctx context.Context, dc dynamic.Interface, name string) (objx.Map, error) {
+	mc := dc.Resource(schema.GroupVersionResource{
+		Group:    machineAPIGroup,
+		Version:  "v1beta1",
+		Resource: "machines",
+	}).Namespace(machineAPINamespace)
+
+	obj, err := mc.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return objx.Map(obj.UnstructuredContent()), nil
+}

--- a/test/extended/openstack/ocpbug_1765.go
+++ b/test/extended/openstack/ocpbug_1765.go
@@ -1,14 +1,17 @@
 package openstack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
@@ -21,9 +24,11 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+
 	"k8s.io/client-go/rest"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -37,6 +42,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 	var cfg *rest.Config
 	var clientSet *kubernetes.Clientset
 	var networkClient *gophercloud.ServiceClient
+	//	var computeClient *gophercloud.ServiceClient
 	oc := exutil.NewCLI("openstack")
 
 	g.BeforeEach(func(ctx g.SpecContext) {
@@ -61,6 +67,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 		// Automation for https://issues.redhat.com/browse/OCPBUGS-1765
 		g.It("[Serial] noAllowedAddressPairs on one port should not affect other ports", func(ctx g.SpecContext) {
 			g.By("Fetching worker machineSets")
+			const subnetCIDR = "192.168.77.0/24"
 			var rawBytes []byte
 			var newProviderSpec machinev1alpha1.OpenstackProviderSpec
 			var rclient runtimeclient.Client
@@ -82,11 +89,18 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 			rclient, err = runtimeclient.New(cfg, runtimeclient.Options{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error creating a runtime client")
 
+			workerUUID := getFirstWorkerID(clientSet, ctx)
+			workerAddressPairs := getInstancePortsAllowedAddressPairs(ctx, networkClient, workerUUID)
+
 			g.By("Create an additional OpenStack Network")
 			extraNetworkName := fmt.Sprintf("%v-%v", "foonet", RandomSuffix())
 			networkCreateOpts := networks.CreateOpts{Name: extraNetworkName}
 			extraNetwork, err := networks.Create(ctx, networkClient, networkCreateOpts).Extract()
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error creating network")
+			subnetCreateOpts := subnets.CreateOpts{Name: extraNetworkName, NetworkID: extraNetwork.ID, CIDR: subnetCIDR, IPVersion: gophercloud.IPv4}
+			_, err = subnets.Create(ctx, networkClient, subnetCreateOpts).Extract()
+			o.Expect(err).NotTo(o.HaveOccurred(), "Error creating subnet")
+
 			g.By(fmt.Sprintf("Network %v was created", extraNetwork.Name))
 			defer networks.Delete(ctx, networkClient, extraNetwork.ID)
 
@@ -96,6 +110,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to add Machine to scheme")
 			err = configv1.AddToScheme(scheme.Scheme)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to add Config to scheme")
+
 			// BuildMachineSetParams builds a MachineSetParams object from the first worker MachineSet retrieved from the cluster.
 			newMachinesetParams := framework.BuildMachineSetParams(ctx, rclient, 1)
 			rawBytes, err = json.Marshal(newMachinesetParams.ProviderSpec.Value)
@@ -103,6 +118,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 			err = json.Unmarshal(rawBytes, &newProviderSpec)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error unmarshaling new MachineSet Provider Spec")
 			newMachinesetParams.Name = fmt.Sprintf("%v-%v", "extra-network", RandomSuffix())
+
 			// Set NoAlloedAddressPairs for the additional network to true
 			var extraNetworkParam machinev1alpha1.NetworkParam
 			extraNetworkParam.NoAllowedAddressPairs = true
@@ -122,51 +138,33 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 
 			newMachines, err := machines.List(ctx, dc, machines.ByMachineSet(ms.Labels["machine.openshift.io/cluster-api-machineset"]))
 			o.Expect(err).NotTo(o.HaveOccurred(), "Error fetching machines for MachineSet %q", ms.Name)
-			machineNetworks := make(map[string]string)
 
-			for _, machine := range newMachines {
-				for _, net := range objects(machine.Get("spec.providerSpec.value.networks")) {
-					// We either have a network id with the uuid key or with filter.id
-					netID := net.Get("uuid").String()
-					if netID != "" {
-						machineNetworks[net.Get("uuid").String()] = net.Get("noAllowedAddressPairs").String()
-					} else {
-						machineNetworks[net.Get("filter.id").String()] = net.Get("noAllowedAddressPairs").String()
-					}
-				}
-			}
 			g.By("Verify the number of networks in the new machine is as expected")
-			o.Expect(len(machineNetworks)).To(o.Equal(len(newProviderSpec.Networks)))
+			newMachineName := newMachines[0].Get("metadata.name").Str()
+			// Wait until the machine is provisioned to get the Openstack instance id
+			waitUntilMachinePhase(ctx, dc, newMachineName, "Provisioned")
+
+			newMachine, err := machines.Get(ctx, dc, newMachineName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			instanceUUID := strings.TrimPrefix(newMachine.Get("spec.providerID").String(), "openstack:///")
+			instanceAddressPairs := getInstancePortsAllowedAddressPairs(ctx, networkClient, instanceUUID)
+			o.Expect(len(instanceAddressPairs)).To(o.Equal(len(workerAddressPairs) + 1))
+
 			g.By("Verify that the new machine has the extra network")
-			_, ok := machineNetworks[extraNetwork.ID]
+			_, ok := instanceAddressPairs[extraNetwork.ID]
 			o.Expect(ok).To(o.BeTrue())
 
 			g.By("Verify value of ports AllowedAddressPairs for all the Machines")
-			e2e.Logf("machineNetworks: %v", machineNetworks)
-			for net, allowedAddressPairs := range machineNetworks {
-				portListOpts := ports.ListOpts{
-					NetworkID: net,
-				}
-				allPages, err := ports.List(networkClient, portListOpts).AllPages(ctx)
-				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get ports")
-				allPorts, err := ports.ExtractPorts(allPages)
-				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to extract ports")
-				// Make sure we have at least one port per network
-				o.Expect(len(allPorts)).Should(o.BeNumerically(">=", 1))
-
-				for _, port := range allPorts {
-					if strings.Contains(port.Name, newMachinesetParams.Name) {
-						if allowedAddressPairs == "true" {
-							// There should be a port in the additional network with
-							// an empty AllowedAddressPairs
-							o.Expect(len(port.AllowedAddressPairs)).To(o.Equal(0))
-						} else {
-							// For other ports AllowedAddressPairs shouldn't be empty
-							o.Expect(len(port.AllowedAddressPairs)).To(o.Not(o.Equal(0)))
-						}
-					}
+			for net, addressPairs := range instanceAddressPairs {
+				if net == extraNetwork.ID {
+					o.Expect(addressPairs).To(o.Equal(0))
+				} else {
+					e2e.Logf("Not extra network")
+					o.Expect(instanceAddressPairs[net]).To(o.Equal(addressPairs))
 				}
 			}
+
 			g.By("Deleting the new machineset")
 			framework.DeleteMachineSets(rclient, ms)
 			err = GetMachinesetRetry(ctx, rclient, ms, false)
@@ -178,3 +176,47 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 		})
 	})
 })
+
+// getFirstWorkerID returns the ID of the first worker node
+func getFirstWorkerID(clientSet *kubernetes.Clientset, ctx context.Context) string {
+	workerNodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/worker",
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	worker := workerNodeList.Items[0]
+	return strings.TrimPrefix(worker.Spec.ProviderID, "openstack:///")
+
+}
+
+// getInstancePortsAllowedAddressPairs returns a map where the the key is a network ID and the value is
+// the length of the port's allowed_address_pairs field in that network attached to instance with ID uuid
+func getInstancePortsAllowedAddressPairs(ctx context.Context, client *gophercloud.ServiceClient, uuid string) map[string]int {
+	portList := make(map[string]int)
+
+	portListOpts := ports.ListOpts{
+		DeviceID: uuid,
+	}
+	allPages, err := ports.List(client, portListOpts).AllPages(ctx)
+	if err != nil {
+		return portList
+	}
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		return portList
+	}
+	for _, port := range allPorts {
+		portList[port.NetworkID] = len(port.AllowedAddressPairs)
+	}
+	return portList
+}
+
+// waitUntilMachinePhase waits until a machine phase is the desired one or a timeout is reached
+func waitUntilMachinePhase(ctx context.Context, dc dynamic.Interface, machineName string, machinePhase string) {
+	wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		machine, err := machines.Get(ctx, dc, machineName)
+		if err != nil {
+			return false, err
+		}
+		return machine.Get("status.phase").Str() == machinePhase, nil
+	})
+}


### PR DESCRIPTION
Fix the failure of test "[sig-installer][Suite:openshift/openstack] Bugfix ocpbug_1765: [It] [Serial] noAllowedAddressPairs on one port should not affect other ports"

The test assumed that the machines networks have either id or uuid keys which are not always the case. Instead of checking the machine's networks the test checks the ports of the openstack instance. It compares the ports' allowed_address_pairs of another worker machine to the ones of the machines. The port of the new network should have allowed_address_pairs set to true while the others ports should have the same value as the other worker.