### PR TITLE
make: Check for updates in cmd before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-openstack-tests: test/extended/openstack/*
+openstack-tests: test/extended/openstack/* cmd/openshift-tests/*
 	go build -o $@ ./cmd/openshift-tests
 
 # Update generated artifacts.


### PR DESCRIPTION
Before this patch, changes in ./cmd/openshift-tests would not trigger recompilation when running `make`.