### PR TITLE
Don't include infra nodes in worker node list

### DIFF
--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -72,7 +72,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			workerNodeList, err = clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-				LabelSelector: "node-role.kubernetes.io/worker",
+				LabelSelector: "node-role.kubernetes.io/worker,!node-role.kubernetes.io/infra",
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
In server group tests.
Otherwise "[sig-installer][Suite:openshift/openstack] The OpenStack platform creates Worker nodes in a server group" test fails because infra nodes and worker nodes are not in the same group.