### PR TITLE
Disregard infra nodes in getFirstWorkerID

### DIFF
--- a/test/extended/openstack/ocpbug_1765.go
+++ b/test/extended/openstack/ocpbug_1765.go
@@ -180,7 +180,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] Bugfix", func() {
 // getFirstWorkerID returns the ID of the first worker node
 func getFirstWorkerID(clientSet *kubernetes.Clientset, ctx context.Context) string {
 	workerNodeList, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: "node-role.kubernetes.io/worker",
+		LabelSelector: "node-role.kubernetes.io/worker,!node-role.kubernetes.io/infra",
 	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	worker := workerNodeList.Items[0]


### PR DESCRIPTION
It was missed in https://github.com/openshift/openstack-test/pull/240" "[sig-installer][Suite:openshift/openstack] Bugfix ocpbug_1765: [Serial] noAllowedAddressPairs on one port should not affect other ports" is failed on a setup with Infra nodes