### PR TITLE
OCPBUGS-59907: Improve egressIP skip "Test not applicable for proxy setup"

### DIFF
--- a/test/extended/openstack/egressip.go
+++ b/test/extended/openstack/egressip.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][egressip] An egre
 		// TODO revert once https://issues.redhat.com/browse/OSASINFRA-3079 is resolved
 		proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		if proxy.Status.HTTPProxy != "" {
+		if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" || proxy.Status.HTTPProxy != "" {
 			e2eskipper.Skipf("Test not applicable for proxy setup")
 		}
 


### PR DESCRIPTION
**What does this PR do?**
Update the egressIP skip "Test not applicable for proxy setup" skipping the test if the env variable `HTTP_PROXY` or `HTTPS_PROXY` is set, which means there is a proxy to access the Cloud.

**Why do we need it?**
The egressIP test doesn't support Cloud/Cluster Infrastructures that are behind a proxy because in those environments the floatingIP/egressIP is a private IP.