### PR TITLE
OCPBUGS-84306: Remove certificate CN assertion from LB ingress test

### DIFF
--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -573,11 +573,11 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 			name := "shard-" + string(uuid.NewUUID())
 			domain := "ingress-canary.openshift-ingress-canary.svc"
 			shardIngressCtrl, err := deployLbIngressController(ctx, oc, 10*time.Minute, name, domain, map[string]string{"ingress.openshift.io/canary": "canary_controller"})
+			o.Expect(err).NotTo(o.HaveOccurred(), "new ingresscontroller did not rollout")
 			defer func() {
 				err := oc.AdminOperatorClient().OperatorV1().IngressControllers(shardIngressCtrl.Namespace).Delete(ctx, shardIngressCtrl.Name, metav1.DeleteOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred(), "error destroying ingress-controller created during the test")
 			}()
-			o.Expect(err).NotTo(o.HaveOccurred(), "new ingresscontroller did not rollout")
 
 			g.By("Checks from openshift perspective")
 			svc, err := oc.AdminKubeClient().CoreV1().Services("openshift-ingress").Get(ctx, "router-"+name, metav1.GetOptions{})
@@ -618,9 +618,9 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				e2e.Logf("Attempting to connect using host: %q", host)
 				resp, err := httpsGetWithCustomLookup(host, svcIp)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				defer resp.Body.Close()
 				o.Expect(resp.Status).Should(o.Equal("200 OK"), "Unexpected response on try #%d", i)
 				body, err := io.ReadAll(resp.Body)
+				resp.Body.Close()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(string(body)).Should(o.Equal("Healthcheck requested\n"), "Unexpected response on try #%d", i)
 			}

--- a/test/extended/openstack/loadbalancers.go
+++ b/test/extended/openstack/loadbalancers.go
@@ -571,8 +571,6 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 
 			g.By("Creating ingresscontroller for sharding the OCP in-built canary service")
 			name := "shard-" + string(uuid.NewUUID())
-			// TODO: Figure out how we can dynamically get the domain name
-			// https://issues.redhat.com//browse/OCPBUGS-35505
 			domain := "ingress-canary.openshift-ingress-canary.svc"
 			shardIngressCtrl, err := deployLbIngressController(ctx, oc, 10*time.Minute, name, domain, map[string]string{"ingress.openshift.io/canary": "canary_controller"})
 			defer func() {
@@ -625,7 +623,6 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack][lb][Serial] The O
 				body, err := io.ReadAll(resp.Body)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(string(body)).Should(o.Equal("Healthcheck requested\n"), "Unexpected response on try #%d", i)
-				o.Expect(fmt.Sprintf("%q", resp.TLS.PeerCertificates[0].Subject)).Should(o.Equal("\"CN="+domain+"\""), "Unexpected response on try #%d", i)
 			}
 			e2e.Logf("Canary service successfully accessed through new ingressController")
 		})


### PR DESCRIPTION
The IngressController LB test fails because the certificate CN served by the canary route through the shard IngressController does not match the hardcoded expected value.

The certificate controller generates a wildcard cert (`CN=*.<domain>`) for each IngressController, but the canary service mirrors the default IngressController's cert (`CN=*.apps.<cluster>`). Which cert the client sees depends on timing and TLS termination behavior, which has changed across OCP versions (see [1]).

Remove the certificate CN assertion entirely. The test's purpose is to verify that a TCP LoadBalancer is created when a LoadBalancerService IngressController is created, not to test certificate management. The test still validates the full TLS-encrypted path: connection, HTTP 200, and correct canary body across 100 iterations.

[1] https://github.com/openshift/openstack-test/pull/175