### PR TITLE
Make tests blocking

### DIFF
--- a/cmd/extension/main.go
+++ b/cmd/extension/main.go
@@ -70,7 +70,7 @@ func main() {
 			spec.Include(et.PlatformEquals(platform))
 		}
 
-		spec.Lifecycle = et.LifecycleInforming
+		spec.Lifecycle = et.LifecycleBlocking
 	})
 
 	ext.AddSpecs(componentSpecs)


### PR DESCRIPTION
The migration tools made them informing by default. Restore their blocking behavior.