### PR TITLE
Tolerate Glance image renames in ProviderSpec image comparison

### DIFF
--- a/test/extended/openstack/machine.go
+++ b/test/extended/openstack/machine.go
@@ -116,7 +116,15 @@ var _ = g.Describe("[OTP][sig-installer][Suite:openshift/openstack] Machine", fu
 				if instance.Image["id"] != nil {
 					instanceImage, err := images.Get(ctx, imageClient, fmt.Sprintf("%v", instance.Image["id"])).Extract()
 					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(instanceImage.Name).To(o.Equal(machineImage), "Image not matching for instance %q", instance.Name)
+					// The RHCOS image in Glance may have been renamed to <name>-old by
+					// refresh_rhcos.sh or the openstack-conf-rhcosimage CI step during
+					// the image update swap. The instance still references the correct
+					// image by ID; only the Glance name changed.
+					o.Expect(instanceImage.Name).To(
+						o.Or(o.Equal(machineImage), o.Equal(machineImage+"-old")),
+						"Image not matching for instance %q: Glance image name %q does not match Machine spec %q",
+						instance.Name, instanceImage.Name, machineImage,
+					)
 				}
 			})
 


### PR DESCRIPTION
## Summary
The RHCOS image in Glance can be renamed from `rhcos-X.Y` to `rhcos-X.Y-old` by `refresh_rhcos.sh` or the `openstack-conf-rhcosimage` CI step during an image update swap. When this happens between cluster installation and test execution, the ProviderSpec test fails because the Glance image name no longer matches the Machine spec — even though the instance is running the correct image (same Glance UUID, same RHCOS content).

This patch accepts both the exact Machine spec name and its `-old` renamed variant in the image comparison, using Gomega's `Or` matcher. The `-old` suffix is the well-known rename pattern used by both `refresh_rhcos.sh` and the CI step. The instance still references the correct image by ID; only the Glance name changed.

This is a companion to the SG fix in PR #264 (cherry-picked in #276), which filtered out `lb-sg-*` security groups from the same test. Together these two changes address the two ProviderSpec sub-failures that have caused 7/10 consecutive failures in `periodic-ci-shiftstack-ci-release-4.22-e2e-openstack-ovn-parallel` from Jun 14–Jul 5.

## Test plan
- [ ] Verify test passes when Glance image name matches Machine spec exactly (`rhcos-4.22`)