### PR TITLE
Bump Containerfile go version to 1.21: release-4.14

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Will be replaced in the CI with registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10
-FROM golang:1.18 AS builder
+FROM golang:1.21 AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
This is an extension of of work in #275. A blind commit
was necessary to test changes, and the docker build
failed in openshift/release rehearsals. Go version
1.18 is not sufficient for the new OTE extensions.
