### PR TITLE
Override default build_root_image to use Go 1.23

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.23-openshift-4.16


### PR DESCRIPTION
This is an extension of of work in #274 

The newer OTE (openshift-test-ext) requires a minimum of go version 1.23. 
Both **rhel-9-release-golang-1.23-openshift-4.14**
and **rhel-9-release-golang-1.23-openshift-4.15** do not exist
however **rhel-9-release-golang-1.23-openshift-4.16** does
and is the earliest supported tag using Go 1.23.

This serves as a workaround which is likely easier to accomplish
the goals of the OTE migration as opposed to downgrading
openshift-test-ext to earlier version.