### PR TITLE
Override default build_root_image to use Go 1.23: release-4.14

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.23-openshift-4.16


### PR DESCRIPTION
This is an extension of of work in #274

The **openstack-test** suites use go version 1.20 which accepts language versions such as **1.20** in the go.mod.  Something like **1.23.0** is rejected outright. Starting in go version 1.21, the patch version becomes mandatory when running `go mod`, and since OTE requires 1.23, the following error is returned when building the binary (CI defaults to using 1.20 for the build for release-4.15):

```
cd tests-extension && GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go build -o /go/src/github.com/openshift/openstack-test/bin/openstack-test-tests-ext ./cmd/extension
go: errors parsing go.mod:
/go/src/github.com/openshift/openstack-test/tests-extension/go.mod:3: invalid go version '1.23.0': must match format 1.23
```

We need to keep openshift-tests around while testing OTE. So as a workaround, it's easier and more consistent to continue using the most recent  OTE versions and use a build container that uses go 1.23. **rhel-9-release-golang-1.23-openshift-4.14** and **rhel-9-release-golang-1.23-openshift-4.15**
do not exist however **rhel-9-release-golang-1.23-openshift-4.16** does (it's earliest supported tag using Go 1.23).

After we migrate fully to OTE, this workaround will no longer be needed and therefore will be dropped from the repository.
