### PR TITLE
OCPBUGS-98468: Create oc CLI without namespace in servergroup spec

### DIFF
--- a/test/extended/openstack/servergroup.go
+++ b/test/extended/openstack/servergroup.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-installer][Suite:openshift/openstack] The OpenStack pla
 	var workerAZGroupNameMap map[string]string
 	var machineList []objx.Map
 
-	oc = exutil.NewCLI("openstack")
+	oc = exutil.NewCLIWithoutNamespace("openstack")
 
 	g.BeforeEach(func(ctx g.SpecContext) {
 		g.By("preparing a dynamic client")


### PR DESCRIPTION
Some jobs have been failing with the following message

```
project.project.openshift.io "e2e-test-openstack-<id>" already exists
```

This PR is an attempt to avoid that two concurrent ginkgo creates projects at the same time, leading to the same project name and therefore a test failure