### PR TITLE
Override default build_root_image to use Go 1.21: release-4.15

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.16
+  tag: rhel-9-release-golang-1.21-openshift-4.15


### PR DESCRIPTION
This is an extension of of work in #274 and #281

OpenShift CI isn't picking up
the `rhel-9-release-golang-1.23-openshift-4.16` configuration.
So, the build stage is still using go 1.20 which results in the
same error.

The .ci-operator.yaml override works as expected in previous
releases (e.g., release-4.18), so it is possible that OCP
CI is refusing to use the 4.16 tag as @mandre predicted in
#281.

The patch version specifier in go.mod was introduced in **go 1.21** and OTE build
has been woking with 1.21 in the Containerfile; so, the
`rhel-9-release-golang-1.21-openshift-4.15` tag is selected
here to build the OTE with a go.mod reference to 1.23.0 ( as opposed to go 1.23)
and use correct OpenShift release tags.

This serves as a workaround which is likely easier to accomplish
the goals of the OTE migration as opposed to downgrading
openshift-test-ext to an earlier version.
