### PR TITLE
Explicitly set -mod flag to mod in OTE build: release-4.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TESTS_EXT_BINARY := bin/openstack-test-tests-ext
 tests-ext-build:
 	@echo "Building OTE test extension binary..."
 	@mkdir -p bin
-	cd tests-extension && GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go build -o $(CURDIR)/$(TESTS_EXT_BINARY) ./cmd/extension
+	cd tests-extension && GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go build -mod=mod -o $(CURDIR)/$(TESTS_EXT_BINARY) ./cmd/extension
 	@echo "Extension binary built: $(TESTS_EXT_BINARY)"
 
 .PHONY: extension


### PR DESCRIPTION
This is a continuation of work completed in #275 and #282.

A separate go module was added alongside `openstack-test` in
order to deal with ginkgo version conflicts. The separate
OTE module is purposely not vendored, because doing so
would introduce duplicate files and bloat the size of the
git objects.

`rhel-9-release-golang-1.23-openshift-4.16` forces vendoring
through the GOFLAGS env var. So, to accomplish building the
OTE binary without vendoring, an explicity command line option
is required.
