### PR TITLE
Remove eurijon from qe-approvers and qe-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,10 +14,8 @@ aliases:
     - mandre
     - stephenfin
   qe-approvers:
-    - eurijon
     - itzikb-redhat
     - rlobillo
   qe-reviewers:
-    - eurijon
     - itzikb-redhat
     - rlobillo


### PR DESCRIPTION
## Summary
- Remove `eurijon` from `qe-approvers` and `qe-reviewers` aliases in OWNERS_ALIASES
- No longer participating in QE reviews for this repository

Assisted-by: Claude Code <noreply@anthropic.com>